### PR TITLE
Dinbandon

### DIFF
--- a/app/Console/Commands/CreateFakeDataCommand.php
+++ b/app/Console/Commands/CreateFakeDataCommand.php
@@ -5,7 +5,7 @@ namespace App\Console\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;
 
-class FakeData extends Command
+class CreateFakeDataCommand extends Command
 {
     /**
      * The name and signature of the console command.

--- a/app/Console/Commands/FakeData.php
+++ b/app/Console/Commands/FakeData.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+
+class FakeData extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:fake-data';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = '生成測試用的使用者、Meeting、便當訂購資料';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        if (app()->environment() !== 'local') {
+            $this->error('This command can only be run in the local environment.');
+            return 1;
+        }
+
+        $this->info('Starting seeding in local environment...');
+
+        $seeders = [
+            'DatabaseSeeder',
+            'MeetingSeeder',
+            'BandonSeeder',
+        ];
+
+        foreach ($seeders as $seeder) {
+            Artisan::call('db:seed', ['--class' => $seeder, '--force' => true]);
+            $this->info("$seeder done.");
+        }
+
+        $this->info('All seeders executed successfully!');
+        return 0;
+    }
+}

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -13,6 +13,7 @@ class OrderController extends Controller
 {
     protected $orderService;
     protected $storeService;
+
     public function __construct(OrderService $orderService, StoreService $storeService)
     {
         $this->orderService = $orderService;
@@ -28,12 +29,12 @@ class OrderController extends Controller
         $orders = collect();
         $ownOrders = collect();
         if ($path === 'dinbandon') {
-            // 取的使用者參與的團夠單資訊
+            // 取的使用者參與的團購單資訊
             $orders = $this->orderService->getParticipatedOrdersInfoByUserId($userId);
         } else {
             // 取得使用者負責的團購單資訊
             $ownOrders = $this->orderService->getManagedOrdersInfoByUserId($userId);
-            // 取的使用者參與的團夠單資訊
+            // 取的使用者參與的團購單資訊
             $orders = $this->orderService->getParticipatedOrdersInfoByUserId($userId);
         }
 

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\GroupOrderRequest;
 use App\Http\Requests\OrderRequest;
 use App\Models\User;
 use App\Services\OrderService;
@@ -42,22 +43,12 @@ class OrderController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(OrderRequest $request)
+    public function store(GroupOrderRequest $request)
     {
-        $validatedData = $request->validated();
-        $orderId = $validatedData['order_id'];
-        $storeId = $validatedData['store_id'];
         $userId = $request->user()->id;
-        $orders = collect($validatedData['orders']);
+        $this->orderService->storeGroupOrder($request, $userId);
 
-        [$numericOrders, $tempOrders] = $orders->partition(function ($order) {
-            return is_numeric($order['id']);
-        });
-
-        $originalOrders = $this->orderService->updateOriginOrder($userId, $orderId, $numericOrders);
-        $newOrders = $this->orderService->storeNewOrder($userId, $orderId, $storeId, $tempOrders);
-
-        return view('welcome');
+        return redirect('/dinbandon/orders');
     }
 
     /**
@@ -85,9 +76,22 @@ class OrderController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, string $id)
+    public function update(OrderRequest $request, string $id)
     {
-        //
+        $validatedData = $request->validated();
+        $orderId = $validatedData['order_id'];
+        $storeId = $validatedData['store_id'];
+        $userId = $request->user()->id;
+        $orders = collect($validatedData['orders']);
+
+        [$numericOrders, $tempOrders] = $orders->partition(function ($order) {
+            return is_numeric($order['id']);
+        });
+
+        $originalOrders = $this->orderService->updateOriginOrder($userId, $orderId, $numericOrders);
+        $newOrders = $this->orderService->storeNewOrder($userId, $orderId, $storeId, $tempOrders);
+
+        return redirect('/dinbandon/orders/' . $orderId);
     }
 
     /**
@@ -96,5 +100,12 @@ class OrderController extends Controller
     public function destroy(string $id)
     {
         //
+    }
+
+    public function storeInfo()
+    {
+        $stores = $this->storeService->getAllStores();
+
+        return view('add-order', compact('stores'));
     }
 }

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\OrderRequest;
 use App\Models\User;
 use App\Services\OrderService;
 use App\Services\StoreService;
@@ -41,9 +42,22 @@ class OrderController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
+    public function store(OrderRequest $request)
     {
-        dd($request);
+        $validatedData = $request->validated();
+        $orderId = $validatedData['order_id'];
+        $storeId = $validatedData['store_id'];
+        $userId = $request->user()->id;
+        $orders = collect($validatedData['orders']);
+
+        [$numericOrders, $tempOrders] = $orders->partition(function ($order) {
+            return is_numeric($order['id']);
+        });
+
+        $originalOrders = $this->orderService->updateOriginOrder($userId, $orderId, $numericOrders);
+        $newOrders = $this->orderService->storeNewOrder($userId, $orderId, $storeId, $tempOrders);
+
+        return view('welcome');
     }
 
     /**

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -62,7 +62,7 @@ class OrderController extends Controller
         $storeInfo = $this->storeService->getStore($storeId);
         $storeMenu = $this->storeService->getMenu($storeId);
         $userOrder = $this->orderService->getOrderInfoByOrderId($id, $userId);
-        // $otherOrder = $this->orderService->
+
         $responseData = collect([
             'order_id' => $id,
             'store_id' => $storeId,
@@ -93,14 +93,6 @@ class OrderController extends Controller
         $newOrders = $this->orderService->storeNewOrder($userId, $orderId, $storeId, $tempOrders);
 
         return redirect('/dinbandon/orders/' . $orderId);
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(string $id)
-    {
-        //
     }
 
     public function storeInfo()

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use App\Services\OrderService;
+use App\Services\StoreService;
+use Illuminate\Http\Request;
+
+class OrderController extends Controller
+{
+    protected $orderService;
+    protected $storeService;
+    public function __construct(OrderService $orderService, StoreService $storeService)
+    {
+        $this->orderService = $orderService;
+        $this->storeService = $storeService;
+    }
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(Request $request)
+    {
+        $userId = $request->user()->id;
+        $path = $request->path();
+        $orders = collect();
+        $ownOrders = collect();
+        if ($path === 'dinbandon') {
+            // 取的使用者參與的團夠單資訊
+            $orders = $this->orderService->getParticipatedOrdersInfoByUserId($userId);
+        } else {
+            // 取得使用者負責的團購單資訊
+            $ownOrders = $this->orderService->getManagedOrdersInfoByUserId($userId);
+            // 取的使用者參與的團夠單資訊
+            $orders = $this->orderService->getParticipatedOrdersInfoByUserId($userId);
+        }
+
+        return view('bandon', compact('orders', 'ownOrders'));
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        dd($request);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id, Request $request)
+    {
+        $userId = $request->user()->id;
+        $storeId = $this->orderService->getStoreIdByOrderId($id);
+        $storeInfo = $this->storeService->getStore($storeId);
+        $storeMenu = $this->storeService->getMenu($storeId);
+        $userOrder = $this->orderService->getOrderInfoByOrderId($id, $userId);
+        // $otherOrder = $this->orderService->
+        $responseData = collect([
+            'order_id' => $id,
+            'store_id' => $storeId,
+            'storeInfo' => $storeInfo,
+            'storeMenu' => $storeMenu,
+            'userOrder' => $userOrder,
+        ]);
+
+        return view('orders', compact('responseData'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/StoreController.php
+++ b/app/Http/Controllers/StoreController.php
@@ -2,12 +2,15 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\Http\Requests\StoreRequest;
+use App\Models\Product;
 use App\Services\StoreService;
 use Illuminate\Http\Request;
 
 class StoreController extends Controller
 {
     protected $storeSerivce;
+    protected $productSerivce;
 
     public function __construct(StoreService $storeSerivce)
     {
@@ -20,15 +23,40 @@ class StoreController extends Controller
     public function index()
     {
         $stores = $this->storeSerivce->getAllStores();
+
         return view('all-bandon', ['stores' => $stores]);
     }
 
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
+    public function store(StoreRequest $request)
     {
-        //
+        $validatedData = $request->validated();
+
+        // 商店資訊寫入資料庫
+        $storeData = [
+            'name' => $validatedData['name'],
+            'phone' => $validatedData['phone'],
+            'address' => $validatedData['address'],
+            'description' => $validatedData['description'],
+        ];
+        $store = $this->storeSerivce->createStore($storeData);
+
+        // 商品寫入資料庫
+        if (isset($validatedData['menu']) && is_array($validatedData['menu'])) {
+            $productData = [];
+            foreach ($validatedData['menu'] as $menuData) {
+                $productData[] = [
+                    'store_id' => $store->id,
+                    'name' => $menuData['name'],
+                    'property' => $menuData['property'],
+                    'price' => $menuData['price'],
+                ];
+            }
+            $this->storeSerivce->insertProduct($productData);
+        }
+        return redirect('dinbandon/stores')->with('success', '已成功新增店家資訊');
     }
 
     /**
@@ -36,7 +64,13 @@ class StoreController extends Controller
      */
     public function show(string $id)
     {
-        dd('1234');
+        $menus = $this->storeSerivce->getMenu($id);
+        $storeInfo = $this->storeSerivce->getStore($id);
+
+        return view('store', [
+            'storeInfo' => $storeInfo,
+            'menus' => $menus
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/StoreController.php
+++ b/app/Http/Controllers/StoreController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\StoreService;
+use Illuminate\Http\Request;
+
+class StoreController extends Controller
+{
+    protected $storeSerivce;
+
+    public function __construct(StoreService $storeSerivce)
+    {
+        $this->storeSerivce = $storeSerivce;
+    }
+
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        $stores = $this->storeSerivce->getAllStores();
+        return view('all-bandon', ['stores' => $stores]);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        dd('1234');
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/StoreController.php
+++ b/app/Http/Controllers/StoreController.php
@@ -55,6 +55,7 @@ class StoreController extends Controller
             }
             $this->storeService->insertProduct($productData);
         }
+
         return redirect('dinbandon/stores')->with('success', '已成功新增店家資訊');
     }
 

--- a/app/Http/Controllers/StoreController.php
+++ b/app/Http/Controllers/StoreController.php
@@ -10,7 +10,6 @@ use Illuminate\Http\Request;
 class StoreController extends Controller
 {
     protected $storeSerivce;
-    protected $productSerivce;
 
     public function __construct(StoreService $storeSerivce)
     {

--- a/app/Http/Controllers/StoreController.php
+++ b/app/Http/Controllers/StoreController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Requests\Http\Requests\StoreRequest;
+use App\Http\Requests\StoreRequest;
 use App\Models\Product;
 use App\Services\StoreService;
 use Illuminate\Http\Request;

--- a/app/Http/Controllers/StoreController.php
+++ b/app/Http/Controllers/StoreController.php
@@ -9,11 +9,11 @@ use Illuminate\Http\Request;
 
 class StoreController extends Controller
 {
-    protected $storeSerivce;
+    protected $storeService;
 
-    public function __construct(StoreService $storeSerivce)
+    public function __construct(StoreService $storeService)
     {
-        $this->storeSerivce = $storeSerivce;
+        $this->storeService = $storeService;
     }
 
     /**
@@ -21,7 +21,7 @@ class StoreController extends Controller
      */
     public function index()
     {
-        $stores = $this->storeSerivce->getAllStores();
+        $stores = $this->storeService->getAllStores();
 
         return view('all-bandon', ['stores' => $stores]);
     }
@@ -40,7 +40,7 @@ class StoreController extends Controller
             'address' => $validatedData['address'],
             'description' => $validatedData['description'],
         ];
-        $store = $this->storeSerivce->createStore($storeData);
+        $store = $this->storeService->createStore($storeData);
 
         // 商品寫入資料庫
         if (isset($validatedData['menu']) && is_array($validatedData['menu'])) {
@@ -53,7 +53,7 @@ class StoreController extends Controller
                     'price' => $menuData['price'],
                 ];
             }
-            $this->storeSerivce->insertProduct($productData);
+            $this->storeService->insertProduct($productData);
         }
         return redirect('dinbandon/stores')->with('success', '已成功新增店家資訊');
     }
@@ -63,28 +63,12 @@ class StoreController extends Controller
      */
     public function show(string $id)
     {
-        $menus = $this->storeSerivce->getMenu($id);
-        $storeInfo = $this->storeSerivce->getStore($id);
+        $menus = $this->storeService->getMenu($id);
+        $storeInfo = $this->storeService->getStore($id);
 
         return view('store', [
             'storeInfo' => $storeInfo,
             'menus' => $menus
         ]);
-    }
-
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, string $id)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(string $id)
-    {
-        //
     }
 }

--- a/app/Http/Requests/GroupOrderRequest.php
+++ b/app/Http/Requests/GroupOrderRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Foundation\Http\FormRequest;
+
+class GroupOrderRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        if (!Auth::check()) {
+            abort(403, '請先登入在進行操作');
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'store_id' => 'required|integer',
+        ];
+    }
+}

--- a/app/Http/Requests/GroupOrderRequest.php
+++ b/app/Http/Requests/GroupOrderRequest.php
@@ -13,7 +13,7 @@ class GroupOrderRequest extends FormRequest
     public function authorize(): bool
     {
         if (!Auth::check()) {
-            abort(403, '請先登入在進行操作');
+            abort(403, '請先登入再進行操作');
         }
 
         return true;

--- a/app/Http/Requests/Http/Requests/StoreRequest.php
+++ b/app/Http/Requests/Http/Requests/StoreRequest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Requests\Http\Requests;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        if (!Auth::check()) {
+            abort(403, '請先登入在進行操作');
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'phone' => 'required|string|max:20',
+            'address' => 'required|string|max:255',
+            'description' => 'required|string',
+            'menu' => 'required|array',
+            'menu.*.name' => 'required|string|max:255',
+            'menu.*.price' => 'required|numeric|min:0',
+            'menu.*.property' => 'required|string|in:S,M,L,份',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'name.required' => '店家名稱為必填。',
+            'phone.required' => '電話為必填。',
+            'address.required' => '地址為必填。',
+            'description.required' => '店家描述為必填。',
+            'menu.required' => '菜單項目不能是空的。',
+            'menu.*.name.required' => '餐點名稱為必填。',
+            'menu.*.price.required' => '餐點價格為必填。',
+            'menu.*.price.numeric' => '餐點價格必須是數字。',
+            'menu.*.price.min' => '餐點價格不能為負數。',
+            'menu.*.property.required' => '餐點屬性為必填。',
+            'menu.*.property.in' => '餐點屬性只能是 S, M, L 或 份。',
+        ];
+    }
+}

--- a/app/Http/Requests/OrderRequest.php
+++ b/app/Http/Requests/OrderRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Foundation\Http\FormRequest;
+
+class OrderRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        if (!Auth::check()) {
+            abort(403, '請先登入在進行操作');
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+
+        return [
+            '_token' => 'required|string',
+            'order_id' => 'required|integer',
+            'store_id' => 'required|integer',
+            'orders' => 'required|array',
+            'orders.*.number' => 'required|integer',
+            'orders.*.is_paid' => 'required|in:0,1',
+            'orders.*.product_name' => 'required|string',
+            'orders.*.total_price' => 'required|numeric',
+            'orders.*.id' => 'required|string',
+            'orders.*.description' => 'nullable|string',
+            'orders.*.product_property' => 'nullable|string',
+        ];
+    }
+}

--- a/app/Http/Requests/OrderRequest.php
+++ b/app/Http/Requests/OrderRequest.php
@@ -13,7 +13,7 @@ class OrderRequest extends FormRequest
     public function authorize(): bool
     {
         if (!Auth::check()) {
-            abort(403, '請先登入在進行操作');
+            abort(403, '請先登入再進行操作');
         }
 
         return true;
@@ -26,7 +26,6 @@ class OrderRequest extends FormRequest
      */
     public function rules(): array
     {
-
         return [
             '_token' => 'required|string',
             'order_id' => 'required|integer',

--- a/app/Http/Requests/StoreRequest.php
+++ b/app/Http/Requests/StoreRequest.php
@@ -13,7 +13,7 @@ class StoreRequest extends FormRequest
     public function authorize(): bool
     {
         if (!Auth::check()) {
-            abort(403, '請先登入在進行操作');
+            abort(403, '請先登入再進行操作');
         }
 
         return true;

--- a/app/Http/Requests/StoreRequest.php
+++ b/app/Http/Requests/StoreRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Requests\Http\Requests;
+namespace App\Http\Requests;
 
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Foundation\Http\FormRequest;

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Order extends Model
+{
+    use HasFactory;
+    public $timestamps = false;
+}

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -10,6 +10,13 @@ class Order extends Model
     use HasFactory;
     public $timestamps = false;
 
+    protected $fillable = [
+        'store_id',
+        'create_user_id',
+        'created_at',
+        'end_at',
+    ];
+
     public function store()
     {
         return $this->belongsTo(Store::class);

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 class Order extends Model
 {
     use HasFactory;
+
     public $timestamps = false;
 
     protected $fillable = [

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -9,4 +9,9 @@ class Order extends Model
 {
     use HasFactory;
     public $timestamps = false;
+
+    public function store()
+    {
+        return $this->belongsTo(Store::class);
+    }
 }

--- a/app/Models/OrderRecord.php
+++ b/app/Models/OrderRecord.php
@@ -4,9 +4,20 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Models\User;
 
 class OrderRecord extends Model
 {
     use HasFactory;
     public $timestamps = false;
+
+    public function product()
+    {
+        return $this->belongsTo(Product::class, 'product_id');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
 }

--- a/app/Models/OrderRecord.php
+++ b/app/Models/OrderRecord.php
@@ -11,6 +11,16 @@ class OrderRecord extends Model
     use HasFactory;
     public $timestamps = false;
 
+    protected $fillable = [
+        'order_id',
+        'user_id',
+        'product_id',
+        'number',
+        'total_price',
+        'is_paid',
+        'description',
+    ];
+
     public function product()
     {
         return $this->belongsTo(Product::class, 'product_id');

--- a/app/Models/OrderRecord.php
+++ b/app/Models/OrderRecord.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class OrderRecord extends Model
+{
+    use HasFactory;
+    public $timestamps = false;
+}

--- a/app/Models/OrderRecord.php
+++ b/app/Models/OrderRecord.php
@@ -9,6 +9,7 @@ use App\Models\User;
 class OrderRecord extends Model
 {
     use HasFactory;
+
     public $timestamps = false;
 
     protected $fillable = [

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Product extends Model
+{
+    use HasFactory;
+    public $timestamps = false;
+}

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -9,4 +9,16 @@ class Product extends Model
 {
     use HasFactory;
     public $timestamps = false;
+
+    protected $fillable = [
+        'user_id',
+        'name',
+        'property',
+        'price',
+    ];
+
+    public function store()
+    {
+        return $this->belongsTo(Store::class);
+    }
 }

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 class Product extends Model
 {
     use HasFactory;
+
     public $timestamps = false;
 
     protected $fillable = [

--- a/app/Models/Store.php
+++ b/app/Models/Store.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Store extends Model
+{
+    use HasFactory;
+    public $timestamps = false;
+}

--- a/app/Models/Store.php
+++ b/app/Models/Store.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 class Store extends Model
 {
     use HasFactory;
+
     public $timestamps = false;
 
     protected $fillable = [

--- a/app/Models/Store.php
+++ b/app/Models/Store.php
@@ -21,4 +21,9 @@ class Store extends Model
     {
         return $this->hasMany(Product::class);
     }
+
+    public function orders()
+    {
+        return $this->hasMany(Order::class, 'store_id', 'id');
+    }
 }

--- a/app/Models/Store.php
+++ b/app/Models/Store.php
@@ -9,4 +9,16 @@ class Store extends Model
 {
     use HasFactory;
     public $timestamps = false;
+
+    protected $fillable = [
+        'name',
+        'phone',
+        'address',
+        'description',
+    ];
+
+    public function menu()
+    {
+        return $this->hasMany(Product::class);
+    }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,8 @@
 namespace App\Providers;
 
 use App\Repositories\Interfaces\StoreRepositoryInterface;
+use App\Repositories\Interfaces\ProductRepositoryInterface;
+use App\Repositories\ProductRepository;
 use App\Repositories\StoreRepository;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
@@ -15,6 +17,7 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->bind(StoreRepositoryInterface::class, StoreRepository::class);
+        $this->app->bind(ProductRepositoryInterface::class,  ProductRepository::class);
     }
 
     /**
@@ -25,5 +28,6 @@ class AppServiceProvider extends ServiceProvider
         Blade::component('components.bandon-info', 'components.bandon-info');
         Blade::component('components.login-form', 'components.login-form');
         Blade::component('components.register-form', 'components.register-form');
+        Blade::component('components.bandon-form', 'components.bandon-form');
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -36,5 +36,6 @@ class AppServiceProvider extends ServiceProvider
         Blade::component('components.register-form', 'components.register-form');
         Blade::component('components.bandon-form', 'components.bandon-form');
         Blade::component('components.bandon-order', 'components.bandon-order');
+        Blade::component('components.bandon-orderlist', 'components.bandon-orderlist');
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Repositories\Interfaces\StoreRepositoryInterface;
+use App\Repositories\StoreRepository;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 
@@ -12,7 +14,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->bind(StoreRepositoryInterface::class, StoreRepository::class);
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,8 +2,12 @@
 
 namespace App\Providers;
 
+use App\Repositories\Interfaces\OrderRecordRepositoryInterface;
+use App\Repositories\Interfaces\OrderRepositoryInterface;
 use App\Repositories\Interfaces\StoreRepositoryInterface;
 use App\Repositories\Interfaces\ProductRepositoryInterface;
+use App\Repositories\OrderRecordRepository;
+use App\Repositories\OrderRepository;
 use App\Repositories\ProductRepository;
 use App\Repositories\StoreRepository;
 use Illuminate\Support\Facades\Blade;
@@ -18,6 +22,8 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->app->bind(StoreRepositoryInterface::class, StoreRepository::class);
         $this->app->bind(ProductRepositoryInterface::class,  ProductRepository::class);
+        $this->app->bind(OrderRepositoryInterface::class,  OrderRepository::class);
+        $this->app->bind(OrderRecordRepositoryInterface::class,  OrderRecordRepository::class);
     }
 
     /**
@@ -29,5 +35,6 @@ class AppServiceProvider extends ServiceProvider
         Blade::component('components.login-form', 'components.login-form');
         Blade::component('components.register-form', 'components.register-form');
         Blade::component('components.bandon-form', 'components.bandon-form');
+        Blade::component('components.bandon-order', 'components.bandon-order');
     }
 }

--- a/app/Repositories/Interfaces/OrderRecordRepositoryInterface.php
+++ b/app/Repositories/Interfaces/OrderRecordRepositoryInterface.php
@@ -7,4 +7,5 @@ interface OrderRecordRepositoryInterface
     public function all();
     public function getOrderId(int $storeId);
     public function create(array $data);
+    public function update(array $data);
 }

--- a/app/Repositories/Interfaces/OrderRecordRepositoryInterface.php
+++ b/app/Repositories/Interfaces/OrderRecordRepositoryInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Repositories\Interfaces;
+
+interface OrderRecordRepositoryInterface
+{
+    public function all();
+    public function getOrderId(int $storeId);
+    public function create(array $data);
+}

--- a/app/Repositories/Interfaces/OrderRepositoryInterface.php
+++ b/app/Repositories/Interfaces/OrderRepositoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Repositories\Interfaces;
+
+use Illuminate\Support\Collection;
+
+interface OrderRepositoryInterface
+{
+    public function findManagedOrdersInfoByUserId(int $userId): Collection;
+    public function findParticipatedOrdersInfoByUserId(int $userId): Collection;
+    public function findOrderInfoByOrderId(int $orderId, int $userId);
+    public function findStoreIdByOrderId(int $orderId);
+}

--- a/app/Repositories/Interfaces/OrderRepositoryInterface.php
+++ b/app/Repositories/Interfaces/OrderRepositoryInterface.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Collection;
 
 interface OrderRepositoryInterface
 {
+    public function create(object $updateData, int $userId);
     public function findManagedOrdersInfoByUserId(int $userId): Collection;
     public function findParticipatedOrdersInfoByUserId(int $userId): Collection;
     public function findOrderInfoByOrderId(int $orderId, int $userId);

--- a/app/Repositories/Interfaces/ProductRepositoryInterface.php
+++ b/app/Repositories/Interfaces/ProductRepositoryInterface.php
@@ -2,8 +2,9 @@
 
 namespace App\Repositories\Interfaces;
 
-interface StoreRepositoryInterface
+interface ProductRepositoryInterface
 {
     public function all();
     public function create(array $data);
+    public function createMany(array $data);
 }

--- a/app/Repositories/Interfaces/ProductRepositoryInterface.php
+++ b/app/Repositories/Interfaces/ProductRepositoryInterface.php
@@ -7,4 +7,5 @@ interface ProductRepositoryInterface
     public function all();
     public function create(array $data);
     public function createMany(array $data);
+    public function getProductId(int $storeId, string $productName, string $productProperty);
 }

--- a/app/Repositories/Interfaces/StoreRepositoryInterface.php
+++ b/app/Repositories/Interfaces/StoreRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?
+
+namespace App\Repositories\Interfaces;
+
+interface StoreRepositoryInterface
+{
+    public function all();
+    public function create(array $data);
+}

--- a/app/Repositories/Interfaces/StoreRepositoryInterface.php
+++ b/app/Repositories/Interfaces/StoreRepositoryInterface.php
@@ -5,5 +5,8 @@ namespace App\Repositories\Interfaces;
 interface StoreRepositoryInterface
 {
     public function all();
+    public function getByIds(array $id);
     public function create(array $data);
+    public function getMenuByStoreId(int $storeId);
+    public function getStoreInfofByStoreId(int $storeId);
 }

--- a/app/Repositories/OrderRecordRepository.php
+++ b/app/Repositories/OrderRecordRepository.php
@@ -10,6 +10,7 @@ class OrderRecordRepository implements OrderRecordRepositoryInterface
     public function all()
     {
         $products = OrderRecord::Paginate(10);
+
         return $products;
     }
 
@@ -38,6 +39,7 @@ class OrderRecordRepository implements OrderRecordRepositoryInterface
                 'description' => $item['description']
             ]);
         }
+
         return true;
     }
 }

--- a/app/Repositories/OrderRecordRepository.php
+++ b/app/Repositories/OrderRecordRepository.php
@@ -25,10 +25,19 @@ class OrderRecordRepository implements OrderRecordRepositoryInterface
 
     public function update(array $data)
     {
-        return OrderRecord::upsert(
-            $data,
-            ['order_id', 'user_id', 'product_id', 'description'],
-            ['number', 'total_price', 'is_paid']
-        );
+        foreach ($data as $item) {
+            OrderRecord::where([
+                'order_id' => $item['order_id'],
+                'user_id' => $item['user_id'],
+                'product_id' => $item['product_id'],
+                'description' => $item['description'],
+            ])->update([
+                'number' => $item['number'],
+                'total_price' => $item['total_price'],
+                'is_paid' => $item['is_paid'],
+                'description' => $item['description']
+            ]);
+        }
+        return true;
     }
 }

--- a/app/Repositories/OrderRecordRepository.php
+++ b/app/Repositories/OrderRecordRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\OrderRecord;
+use App\Repositories\Interfaces\OrderRecordRepositoryInterface;
+
+class OrderRecordRepository implements OrderRecordRepositoryInterface
+{
+    public function all()
+    {
+        $products = OrderRecord::Paginate(10);
+        return $products;
+    }
+
+    public function getOrderId(int $userId)
+    {
+        return OrderRecord::select('order_id')->where('user_id', $userId)->get();
+    }
+
+    public function create(array $data)
+    {
+        return OrderRecord::create($data);
+    }
+}

--- a/app/Repositories/OrderRecordRepository.php
+++ b/app/Repositories/OrderRecordRepository.php
@@ -20,6 +20,15 @@ class OrderRecordRepository implements OrderRecordRepositoryInterface
 
     public function create(array $data)
     {
-        return OrderRecord::create($data);
+        return OrderRecord::insert($data);
+    }
+
+    public function update(array $data)
+    {
+        return OrderRecord::upsert(
+            $data,
+            ['order_id', 'user_id', 'product_id', 'description'],
+            ['number', 'total_price', 'is_paid']
+        );
     }
 }

--- a/app/Repositories/OrderRepository.php
+++ b/app/Repositories/OrderRepository.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\Order;
+use App\Models\OrderRecord;
+use App\Repositories\Interfaces\OrderRepositoryInterface;
+use Illuminate\Support\Collection;
+
+class OrderRepository implements OrderRepositoryInterface
+{
+    public function findManagedOrdersInfoByUserId(int $userId): Collection
+    {
+        return Order::where('create_user_id', $userId)
+            ->with('store:id,name,phone,address')
+            ->select('id', 'store_id', 'end_at')
+            ->get()
+            ->map(function ($order) {
+                return [
+                    'order_id' => $order->id,
+                    'name' => $order->store->name,
+                    'phone' => $order->store->phone,
+                    'address' => $order->store->address,
+                    'end_at' => $order->end_at,
+                ];
+            });
+    }
+
+    public function findParticipatedOrdersInfoByUserId(int $userId): Collection
+    {
+        $participatOrderIds = OrderRecord::where('user_id', $userId)
+            ->distinct()
+            ->pluck('order_id');
+        if ($participatOrderIds->isEmpty()) {
+            return collect();
+        }
+        return Order::wherein('id', $participatOrderIds)
+            ->with('store:id,name,phone,address')
+            ->select('id', 'store_id', 'end_at')
+            ->get()
+            ->map(function ($order) {
+                return [
+                    'order_id' => $order->id,
+                    'name' => $order->store->name,
+                    'phone' => $order->store->phone,
+                    'address' => $order->store->address,
+                    'end_at' => $order->end_at,
+                ];
+            });
+    }
+
+    public function findOrderInfoByOrderId(int $orderId, int $userId)
+    {
+        $isOrderOwner = Order::where('id', $orderId)
+            ->where('create_user_id', $userId)
+            ->first();
+
+        if ($isOrderOwner) {
+            $allOrderRecords = OrderRecord::where('order_id', $orderId)
+                ->with('product:id,name', 'user:id,username') // 确保这里是 'username'
+                ->select('product_id', 'number', 'total_price', 'is_paid', 'description', 'user_id')
+                ->get();
+
+            // 过滤出订单拥有者自己的记录
+            $ownerRecords = $allOrderRecords->filter(function ($record) use ($userId) {
+                return $record->user_id === $userId;
+            })->map(function ($orderRecord) {
+                return [
+                    'product_name' => $orderRecord->product->name,
+                    'number' => $orderRecord->number,
+                    'total_price' => $orderRecord->total_price,
+                    'is_paid' => $orderRecord->is_paid,
+                    'description' => $orderRecord->description,
+                ];
+            });
+
+            // 过滤出其他参与者的记录
+            $otherParticipantsRecords = $allOrderRecords->filter(function ($record) use ($userId) {
+                return $record->user_id !== $userId;
+            })->map(function ($orderRecord) {
+                return [
+                    'user_name' => $orderRecord->user->username,
+                    'product_name' => $orderRecord->product->name,
+                    'number' => $orderRecord->number,
+                    'total_price' => $orderRecord->total_price,
+                    'is_paid' => $orderRecord->is_paid,
+                    'description' => $orderRecord->description,
+                ];
+            });
+
+            return [
+                'myOrderRecords' => $ownerRecords,
+                'otherParticipantsRecords' => $otherParticipantsRecords,
+            ];
+        } else {
+            // 如果用户不是订单拥有者，只返回该用户的记录
+            $myOrderRecords = OrderRecord::where('order_id', $orderId)
+                ->where('user_id', $userId)
+                ->with('product:id,name')
+                ->select('product_id', 'number', 'total_price', 'is_paid', 'description')
+                ->get()
+                ->map(function ($orderRecord) {
+                    return [
+                        'id' => $orderRecord->product_id,
+                        'product_name' => $orderRecord->product->name,
+                        'number' => $orderRecord->number,
+                        'total_price' => $orderRecord->total_price,
+                        'is_paid' => $orderRecord->is_paid,
+                        'description' => $orderRecord->description,
+                    ];
+                });
+            return [
+                'myOrderRecords' => $myOrderRecords,
+            ];
+        }
+    }
+
+    public function findStoreIdByOrderId(int $orderId)
+    {
+        return Order::where('id', $orderId)
+            ->value('store_id');
+    }
+}

--- a/app/Repositories/OrderRepository.php
+++ b/app/Repositories/OrderRepository.php
@@ -18,6 +18,7 @@ class OrderRepository implements OrderRepositoryInterface
             'end_at' => $updateData->end_time,
         ]);
     }
+
     public function findManagedOrdersInfoByUserId(int $userId): Collection
     {
         return Order::where('create_user_id', $userId)
@@ -70,7 +71,7 @@ class OrderRepository implements OrderRepositoryInterface
                 ->select('product_id', 'number', 'total_price', 'is_paid', 'description', 'user_id')
                 ->get();
 
-            // 过滤出订单拥有者自己的记录
+            // 過濾訂單擁有者自己的紀錄
             $ownerRecords = $allOrderRecords->filter(function ($record) use ($userId) {
                 return $record->user_id === $userId;
             })->map(function ($orderRecord) {
@@ -85,7 +86,7 @@ class OrderRepository implements OrderRepositoryInterface
                 ];
             });
 
-            // 过滤出其他参与者的记录
+            // 過濾出其他參與者的紀錄
             $otherParticipantsRecords = $allOrderRecords->filter(function ($record) use ($userId) {
                 return $record->user_id !== $userId;
             })->map(function ($orderRecord) {
@@ -106,7 +107,7 @@ class OrderRepository implements OrderRepositoryInterface
                 'otherParticipantsRecords' => $otherParticipantsRecords,
             ];
         } else {
-            // 如果用户不是订单拥有者，只返回该用户的记录
+            // 用戶非擁有者，只返回該用戶的紀錄
             $myOrderRecords = OrderRecord::where('order_id', $orderId)
                 ->where('user_id', $userId)
                 ->with('product:id,name,property')

--- a/app/Repositories/OrderRepository.php
+++ b/app/Repositories/OrderRepository.php
@@ -57,8 +57,8 @@ class OrderRepository implements OrderRepositoryInterface
 
         if ($isOrderOwner) {
             $allOrderRecords = OrderRecord::where('order_id', $orderId)
-                ->with('product:id,name,property', 'user:id,username') // 确保这里是 'username'
-                ->select('product_id', 'number', 'total_price', 'is_paid', 'description', 'user_id', 'product.property')
+                ->with('product:id,name,property', 'user:id,username')
+                ->select('product_id', 'number', 'total_price', 'is_paid', 'description', 'user_id')
                 ->get();
 
             // 过滤出订单拥有者自己的记录
@@ -66,6 +66,7 @@ class OrderRepository implements OrderRepositoryInterface
                 return $record->user_id === $userId;
             })->map(function ($orderRecord) {
                 return [
+                    'id' => $orderRecord->product_id,
                     'product_name' => $orderRecord->product->name,
                     'number' => $orderRecord->number,
                     'total_price' => $orderRecord->total_price,
@@ -80,6 +81,7 @@ class OrderRepository implements OrderRepositoryInterface
                 return $record->user_id !== $userId;
             })->map(function ($orderRecord) {
                 return [
+                    'id' => $orderRecord->product_id,
                     'user_name' => $orderRecord->user->username,
                     'product_name' => $orderRecord->product->name,
                     'number' => $orderRecord->number,
@@ -112,6 +114,7 @@ class OrderRepository implements OrderRepositoryInterface
                         'property' => $orderRecord->product->property,
                     ];
                 });
+
             return [
                 'myOrderRecords' => $myOrderRecords,
             ];

--- a/app/Repositories/OrderRepository.php
+++ b/app/Repositories/OrderRepository.php
@@ -9,6 +9,15 @@ use Illuminate\Support\Collection;
 
 class OrderRepository implements OrderRepositoryInterface
 {
+    public function create(object $updateData, int $userId)
+    {
+        return Order::create([
+            'store_id' => $updateData->store_id,
+            'create_user_id' => $userId,
+            'created_at' => $updateData->start_time,
+            'end_at' => $updateData->end_time,
+        ]);
+    }
     public function findManagedOrdersInfoByUserId(int $userId): Collection
     {
         return Order::where('create_user_id', $userId)

--- a/app/Repositories/OrderRepository.php
+++ b/app/Repositories/OrderRepository.php
@@ -57,8 +57,8 @@ class OrderRepository implements OrderRepositoryInterface
 
         if ($isOrderOwner) {
             $allOrderRecords = OrderRecord::where('order_id', $orderId)
-                ->with('product:id,name', 'user:id,username') // 确保这里是 'username'
-                ->select('product_id', 'number', 'total_price', 'is_paid', 'description', 'user_id')
+                ->with('product:id,name,property', 'user:id,username') // 确保这里是 'username'
+                ->select('product_id', 'number', 'total_price', 'is_paid', 'description', 'user_id', 'product.property')
                 ->get();
 
             // 过滤出订单拥有者自己的记录
@@ -71,6 +71,7 @@ class OrderRepository implements OrderRepositoryInterface
                     'total_price' => $orderRecord->total_price,
                     'is_paid' => $orderRecord->is_paid,
                     'description' => $orderRecord->description,
+                    'property' => $orderRecord->product->property,
                 ];
             });
 
@@ -85,6 +86,7 @@ class OrderRepository implements OrderRepositoryInterface
                     'total_price' => $orderRecord->total_price,
                     'is_paid' => $orderRecord->is_paid,
                     'description' => $orderRecord->description,
+                    'property' => $orderRecord->product->property,
                 ];
             });
 
@@ -96,7 +98,7 @@ class OrderRepository implements OrderRepositoryInterface
             // 如果用户不是订单拥有者，只返回该用户的记录
             $myOrderRecords = OrderRecord::where('order_id', $orderId)
                 ->where('user_id', $userId)
-                ->with('product:id,name')
+                ->with('product:id,name,property')
                 ->select('product_id', 'number', 'total_price', 'is_paid', 'description')
                 ->get()
                 ->map(function ($orderRecord) {
@@ -107,6 +109,7 @@ class OrderRepository implements OrderRepositoryInterface
                         'total_price' => $orderRecord->total_price,
                         'is_paid' => $orderRecord->is_paid,
                         'description' => $orderRecord->description,
+                        'property' => $orderRecord->product->property,
                     ];
                 });
             return [

--- a/app/Repositories/ProductRepository.php
+++ b/app/Repositories/ProductRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\Product;
+use App\Repositories\Interfaces\ProductRepositoryInterface;
+
+class ProductRepository implements ProductRepositoryInterface
+{
+    public function all()
+    {
+        $products = Product::Paginate(10);
+        return $products;
+    }
+
+    public function create(array $data)
+    {
+        return Product::create($data);
+    }
+
+    public function createMany(array $data)
+    {
+        return Product::insert($data);
+    }
+}

--- a/app/Repositories/ProductRepository.php
+++ b/app/Repositories/ProductRepository.php
@@ -22,4 +22,12 @@ class ProductRepository implements ProductRepositoryInterface
     {
         return Product::insert($data);
     }
+
+    public function getProductId(int $storeId, string $productName, string $productProperty)
+    {
+        return Product::where('store_id', $storeId)
+            ->where('name', $productName)
+            ->where('property', $productProperty)
+            ->value('id');
+    }
 }

--- a/app/Repositories/StoreRepository.php
+++ b/app/Repositories/StoreRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Repositories;
 
+use App\Models\Product;
 use App\Models\Store;
 use App\Repositories\Interfaces\StoreRepositoryInterface;
 
@@ -13,8 +14,45 @@ class StoreRepository implements StoreRepositoryInterface
         return $stores;
     }
 
+    public function getByIds(array $id)
+    {
+        return Store::select('name', 'phone', 'address', 'description')
+            ->whereIn('id', $id)
+            ->get();
+    }
+
     public function create(array $data)
     {
         return Store::create($data);
+    }
+
+    public function getMenuByStoreId(int $storeId)
+    {
+        return Product::select('id', 'name', 'property', 'price')
+            ->where('store_id', $storeId)
+            ->orderBy('name')
+            ->get()
+            ->map(function ($menu) {
+                return [
+                    'name' => $menu->name,
+                    'property' => $menu->property,
+                    'price' => $menu->price,
+                ];
+            });
+    }
+
+    public function getStoreInfofByStoreId(int $storeId)
+    {
+        return Store::select('name', 'phone', 'address', 'description')
+            ->where('id', $storeId)
+            ->get()
+            ->map(function ($storeInfo) {
+                return [
+                    'name' => $storeInfo->name,
+                    'phone' => $storeInfo->phone,
+                    'address' => $storeInfo->address,
+                    'description' => $storeInfo->description,
+                ];
+            });
     }
 }

--- a/app/Repositories/StoreRepository.php
+++ b/app/Repositories/StoreRepository.php
@@ -1,0 +1,20 @@
+<?
+
+namespace App\Repositories;
+
+use App\Models\Store;
+use App\Repositories\Interfaces\StoreRepositoryInterface;
+
+class StoreRepository implements StoreRepositoryInterface
+{
+    public function all()
+    {
+        $stores = Store::Paginate(10);;
+        return $stores;
+    }
+
+    public function create(array $data)
+    {
+        // return Store::create($data);
+    }
+}

--- a/app/Repositories/StoreRepository.php
+++ b/app/Repositories/StoreRepository.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 namespace App\Repositories;
 
@@ -15,6 +15,6 @@ class StoreRepository implements StoreRepositoryInterface
 
     public function create(array $data)
     {
-        // return Store::create($data);
+        return Store::create($data);
     }
 }

--- a/app/Repositories/StoreRepository.php
+++ b/app/Repositories/StoreRepository.php
@@ -10,7 +10,7 @@ class StoreRepository implements StoreRepositoryInterface
 {
     public function all()
     {
-        $stores = Store::Paginate(10);;
+        $stores = Store::Paginate(10);
         return $stores;
     }
 

--- a/app/Services/OrderService.php
+++ b/app/Services/OrderService.php
@@ -50,7 +50,7 @@ class OrderService
                 'number' => $item['number'],
                 'total_price' => $item['total_price'],
                 'is_paid' => $item['is_paid'],
-                'description' => $item['description'],
+                'description' => $item['description'] ?? '',
             ];
         }
         $this->orderRecordRepository->update($updateData);
@@ -67,7 +67,7 @@ class OrderService
                 'number' => $item['number'],
                 'total_price' => $item['total_price'],
                 'is_paid' => $item['is_paid'],
-                'description' => $item['description'],
+                'description' => $item['description'] ?? '',
             ];
         }
 

--- a/app/Services/OrderService.php
+++ b/app/Services/OrderService.php
@@ -73,4 +73,9 @@ class OrderService
 
         $this->orderRecordRepository->create($updateData);
     }
+
+    public function storeGroupOrder(object $updateData, int $userId)
+    {
+        return $this->orderRepository->create($updateData, $userId);
+    }
 }

--- a/app/Services/OrderService.php
+++ b/app/Services/OrderService.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Services;
+
+use App\Repositories\Interfaces\OrderRecordRepositoryInterface;
+use App\Repositories\Interfaces\OrderRepositoryInterface;
+use Illuminate\Database\Eloquent\Collection;
+
+class OrderService
+{
+    protected $orderRepository;
+    protected $orderRecordRepository;
+
+    public function __construct(OrderRepositoryInterface $orderRepository, OrderRecordRepositoryInterface $orderRecordRepository)
+    {
+        $this->orderRepository = $orderRepository;
+        $this->orderRecordRepository = $orderRecordRepository;
+    }
+
+    public function getStoreIdByOrderId(int $orderId)
+    {
+        return $this->orderRepository->findStoreIdByOrderId($orderId);
+    }
+
+    public function getManagedOrdersInfoByUserId(int $userId)
+    {
+        return $this->orderRepository->findManagedOrdersInfoByUserId($userId);
+    }
+
+    public function getParticipatedOrdersInfoByUserId(int $userId)
+    {
+        return $this->orderRepository->findParticipatedOrdersInfoByUserId($userId);
+    }
+
+    public function getOrderInfoByOrderId(int $orderId, int $userId)
+    {
+        return $this->orderRepository->findOrderInfoByOrderId($orderId, $userId);
+    }
+}

--- a/app/Services/OrderService.php
+++ b/app/Services/OrderService.php
@@ -12,6 +12,7 @@ class OrderService
     protected $orderRepository;
     protected $orderRecordRepository;
     protected $productRepository;
+
     public function __construct(OrderRepositoryInterface $orderRepository, OrderRecordRepositoryInterface $orderRecordRepository, ProductRepositoryInterface $productRepository)
     {
         $this->orderRepository = $orderRepository;

--- a/app/Services/OrderService.php
+++ b/app/Services/OrderService.php
@@ -4,17 +4,19 @@ namespace App\Services;
 
 use App\Repositories\Interfaces\OrderRecordRepositoryInterface;
 use App\Repositories\Interfaces\OrderRepositoryInterface;
+use App\Repositories\Interfaces\ProductRepositoryInterface;
 use Illuminate\Database\Eloquent\Collection;
 
 class OrderService
 {
     protected $orderRepository;
     protected $orderRecordRepository;
-
-    public function __construct(OrderRepositoryInterface $orderRepository, OrderRecordRepositoryInterface $orderRecordRepository)
+    protected $productRepository;
+    public function __construct(OrderRepositoryInterface $orderRepository, OrderRecordRepositoryInterface $orderRecordRepository, ProductRepositoryInterface $productRepository)
     {
         $this->orderRepository = $orderRepository;
         $this->orderRecordRepository = $orderRecordRepository;
+        $this->productRepository = $productRepository;
     }
 
     public function getStoreIdByOrderId(int $orderId)
@@ -35,5 +37,40 @@ class OrderService
     public function getOrderInfoByOrderId(int $orderId, int $userId)
     {
         return $this->orderRepository->findOrderInfoByOrderId($orderId, $userId);
+    }
+
+    public function updateOriginOrder(int $userId, int $orderId, object $items)
+    {
+        $updateData = [];
+        foreach ($items as $item) {
+            $updateData[] = [
+                'order_id' => $orderId,
+                'user_id' => $userId,
+                'product_id' => $item['id'],
+                'number' => $item['number'],
+                'total_price' => $item['total_price'],
+                'is_paid' => $item['is_paid'],
+                'description' => $item['description'],
+            ];
+        }
+        $this->orderRecordRepository->update($updateData);
+    }
+
+    public function storeNewOrder(int $userId, int $orderId, int $storeId, object $items)
+    {
+        $updateData = [];
+        foreach ($items as $item) {
+            $updateData[] = [
+                'order_id' => $orderId,
+                'user_id' => $userId,
+                'product_id' => $this->productRepository->getProductId($storeId, $item['product_name'], $item['product_property']),
+                'number' => $item['number'],
+                'total_price' => $item['total_price'],
+                'is_paid' => $item['is_paid'],
+                'description' => $item['description'],
+            ];
+        }
+
+        $this->orderRecordRepository->create($updateData);
     }
 }

--- a/app/Services/StoreService.php
+++ b/app/Services/StoreService.php
@@ -2,20 +2,49 @@
 
 namespace App\Services;
 
+use App\Models\Product;
+use App\Models\Store;
+use App\Repositories\Interfaces\ProductRepositoryInterface;
 use App\Repositories\Interfaces\StoreRepositoryInterface;
 use Illuminate\Database\Eloquent\Collection;
 
 class StoreService
 {
     protected $storeRepository;
+    protected $productRepository;
 
-    public function __construct(StoreRepositoryInterface $storeRepository)
+    public function __construct(StoreRepositoryInterface $storeRepository, ProductRepositoryInterface $productRepository)
     {
         $this->storeRepository = $storeRepository;
+        $this->productRepository = $productRepository;
     }
 
     public function getAllStores()
     {
         return $this->storeRepository->all();
+    }
+
+    public function getStore($id)
+    {
+        $store = Store::select('name', 'phone', 'address', 'description')->where('id', $id)->first();
+
+        return $store;
+    }
+
+    public function getMenu($id)
+    {
+        $menus = Product::select('id', 'name', 'property', 'price')->where('store_id', $id)->orderBy('name')->get();
+
+        return $menus;
+    }
+
+    public function createStore(array $data)
+    {
+        return $this->storeRepository->create($data);
+    }
+
+    public function insertProduct(array $data)
+    {
+        return $this->productRepository->createMany($data);
     }
 }

--- a/app/Services/StoreService.php
+++ b/app/Services/StoreService.php
@@ -24,18 +24,19 @@ class StoreService
         return $this->storeRepository->all();
     }
 
-    public function getStore($id)
+    public function getStore(int $storeId)
     {
-        $store = Store::select('name', 'phone', 'address', 'description')->where('id', $id)->first();
-
-        return $store;
+        return $this->storeRepository->getStoreInfofByStoreId($storeId);
     }
 
-    public function getMenu($id)
+    public function getStoresByIds(array $id)
     {
-        $menus = Product::select('id', 'name', 'property', 'price')->where('store_id', $id)->orderBy('name')->get();
+        return $this->storeRepository->getByIds($id);
+    }
 
-        return $menus;
+    public function getMenu(int $storeId)
+    {
+        return  $this->storeRepository->getMenuByStoreId($storeId);;
     }
 
     public function createStore(array $data)

--- a/app/Services/StoreService.php
+++ b/app/Services/StoreService.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Services;
+
+use App\Repositories\Interfaces\StoreRepositoryInterface;
+use Illuminate\Database\Eloquent\Collection;
+
+class StoreService
+{
+    protected $storeRepository;
+
+    public function __construct(StoreRepositoryInterface $storeRepository)
+    {
+        $this->storeRepository = $storeRepository;
+    }
+
+    public function getAllStores()
+    {
+        return $this->storeRepository->all();
+    }
+}

--- a/database/factories/OrderFactory.php
+++ b/database/factories/OrderFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Store;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Model>
+ */
+class OrderFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $createdAt = fake()->dateTimeBetween('+1 days', '+10 days')->setTime(rand(8, 14), 0, 0);;
+        $endAt = (clone $createdAt)->modify('+1 hours');
+        
+        return [
+            'store_id' => Store::inRandomOrder()->first()->id,
+            'create_user_id' => User::inRandomOrder()->first()->id,
+            'created_at' => $createdAt,
+            'end_at' => $endAt,
+        ];
+    }
+}

--- a/database/factories/OrderRecordFactory.php
+++ b/database/factories/OrderRecordFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Order;
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Model>
+ */
+class OrderRecordFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $productId = Product::inRandomOrder()->first()->id;
+        $number = fake()->numberBetween(1,8);
+        $totalPrice = Product::where('id',$productId)->value('price') * $number;
+
+        return [
+            'order_id' => Order::inRandomOrder()->first()->id,
+            'user_id' => User::inRandomOrder()->first()->id,
+            'product_id' => $productId,
+            'number' => $number,
+            'total_price' => $totalPrice,
+            'is_paid' => fake()->numberBetween(0,1),
+            'description' => fake()->text(),
+        ];
+    }
+}

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Store;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Model>
+ */
+class ProductFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $foods = [
+            'Burger', 'Pizza', 'Sushi', 'Pasta', 'Ramen',
+            'Salad', 'Taco', 'Steak', 'Fried Chicken', 'Curry',
+            'Dumpling', 'Sandwich', 'Noodles', 'Ice Cream', 'Donut',
+            'Hot Dog', 'Spring Roll', 'Bibimbap', 'Kebab', 'Burrito',
+            'Falafel', 'Lasagna', 'Quiche', 'Gyoza', 'Pad Thai',
+            'Grilled Cheese', 'Fish and Chips', 'Chow Mein', 'Meatball', 'Risotto',
+            'Water', 'Coca Cola', 'Pepsi', 'Sprite', 'Fanta',
+            'Iced Tea', 'Lemonade', 'Orange Juice', 'Apple Juice', 'Grape Juice',
+            'Milk', 'Soy Milk', 'Coffee', 'Latte', 'Cappuccino',
+            'Espresso', 'Green Tea', 'Black Tea', 'Oolong Tea', 'Bubble Tea',
+            'Smoothie', 'Milkshake', 'Hot Chocolate', 'Energy Drink', 'Sports Drink',
+            'Herbal Tea', 'Chai', 'Matcha', 'Soda Water','Tonic Water'
+        ];
+        
+        $property = [ 'Piece', 'Slice', 'Portion', 'Serving', 'L', 'M', 'S' ];
+
+        return [
+            'store_id' => Store::inRandomOrder()->first()->id,
+            'name' => fake()->randomElement($foods),
+            'property' => fake()->randomElement($property),
+            'price' => fake()->randomFloat(2,1,90),
+        ];
+    }
+}

--- a/database/factories/StoreFactory.php
+++ b/database/factories/StoreFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Model>
+ */
+class StoreFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->name(),
+            'phone' => fake()->phoneNumber(),
+            'address' => fake()->address(),
+            'description' => fake()->realText(),
+        ];
+    }
+}

--- a/database/migrations/2025_05_23_072301_change_price_type_on_order_records_table.php
+++ b/database/migrations/2025_05_23_072301_change_price_type_on_order_records_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('order_records', function (Blueprint $table) {
+            $table->decimal('total_price', 10, 2)->unsigned()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('order_records', function (Blueprint $table) {
+            $table->integer('total_price')->change();
+        }); 
+    }
+};

--- a/database/migrations/2025_05_23_074306_fix_product_id_foreign_key_on_order_records_table.php
+++ b/database/migrations/2025_05_23_074306_fix_product_id_foreign_key_on_order_records_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('order_records', function (Blueprint $table) {
+            $table->dropForeign(['product_id']);
+            $table->unsignedBigInteger('product_id')->change();
+            $table->foreign('product_id')->references('id')->on('products')->onDelete('cascade')->onUpdate('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('order_records', function (Blueprint $table) {
+            $table->dropForeign(['product_id']);
+            $table->unsignedBigInteger('product_id')->change();
+            // 這個原本的關聯就是錯誤的，但如果資料庫是有資料的狀況 rollback 可能會造成 product_id 對應不到 users 表中的 id，導致錯誤產生
+            // 故這邊不還原至原本的對應
+            $table->foreign('product_id')->references('id')->on('products')->onDelete('cascade')->onUpdate('cascade');
+        });
+    }
+};

--- a/database/migrations/2025_06_14_080218_make_description_nullable_in_order_records_table.php
+++ b/database/migrations/2025_06_14_080218_make_description_nullable_in_order_records_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Models\OrderRecord;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('order_records', function (Blueprint $table) {
+            $table->string('description')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // 避免rollback跟Null值的欄位產生衝突
+        OrderRecord::whereNull('description')
+            ->update(['description' => '']);
+
+        Schema::table('order_records', function (Blueprint $table) {
+            $table->string('description')->nullable(false)->change();
+        });
+    }
+};

--- a/database/seeders/BandonSeeder.php
+++ b/database/seeders/BandonSeeder.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Order;
+use App\Models\OrderRecord;
+use App\Models\Product;
+use App\Models\Store;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class BandonSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Store::factory(20)->create();
+        Product::factory(300)->create();
+        Order::factory(50)->create();
+        OrderRecord::factory(50)->create();
+    }
+}

--- a/resources/views/Components/bandon-form.blade.php
+++ b/resources/views/Components/bandon-form.blade.php
@@ -1,0 +1,156 @@
+<style>
+    .form-container {
+        background-color: #fff;
+        padding: 2rem;
+        border-radius: 8px;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+
+    .form-group {
+        margin-bottom: 1.5rem;
+    }
+
+    .form-label {
+        display: block;
+        margin-bottom: 0.5rem;
+        font-weight: 600;
+        color: #333;
+    }
+
+    .form-input {
+        width: 100%;
+        padding: 0.75rem;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        font-size: 1rem;
+    }
+
+    .form-textarea {
+        width: 100%;
+        padding: 0.75rem;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        min-height: 100px;
+        resize: vertical;
+    }
+
+    .menu-container {
+        margin-top: 2rem;
+        padding: 1rem;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+    }
+
+    .menu-item {
+        display: grid;
+        grid-template-columns: 2fr 1fr 1fr;
+        gap: 1rem;
+        margin-bottom: 1rem;
+        padding: 1rem;
+        background-color: #f8f9fa;
+        border-radius: 4px;
+    }
+
+    .btn {
+        padding: 0.75rem 1.5rem;
+        border: none;
+        border-radius: 4px;
+        font-size: 1rem;
+        cursor: pointer;
+        transition: background-color 0.2s;
+    }
+
+    .btn-primary {
+        background-color: #3498db;
+        color: white;
+    }
+
+    .btn-primary:hover {
+        background-color: #2980b9;
+    }
+
+    .btn-secondary {
+        background-color: #95a5a6;
+        color: white;
+    }
+
+    .btn-secondary:hover {
+        background-color: #7f8c8d;
+    }
+
+    .btn-danger {
+        background-color: #e74c3c;
+        color: white;
+    }
+
+    .btn-danger:hover {
+        background-color: #c0392b;
+    }
+</style>
+
+<form action="/dinbandon/stores" method="POST" class="form-container">
+    @csrf
+    <div class="form-group">
+        <label class="form-label" for="name">店家名稱</label>
+        <input type="text" id="name" name="name" class="form-input" required>
+    </div>
+
+    <div class="form-group">
+        <label class="form-label" for="phone">電話</label>
+        <input type="tel" id="phone" name="phone" class="form-input" required>
+    </div>
+
+    <div class="form-group">
+        <label class="form-label" for="address">地址</label>
+        <input type="text" id="address" name="address" class="form-input" required>
+    </div>
+
+    <div class="form-group">
+        <label class="form-label" for="description">店家描述</label>
+        <textarea id="description" name="description" class="form-textarea"></textarea>
+    </div>
+
+    <div class="menu-container">
+        <h3>菜單項目</h3>
+        <div id="menu-items">
+            <div class="menu-item">
+                <input type="text" name="menu[0][name]" class="form-input" placeholder="餐點名稱" required>
+                <input type="number" name="menu[0][price]" class="form-input" placeholder="價格" step="0.01" required>
+                <select name="menu[0][property]" class="form-input" required>
+                    <option value="S">S</option>
+                    <option value="M">M</option>
+                    <option value="L">L</option>
+                    <option value="份">份</option>
+                </select>
+            </div>
+        </div>
+        <button type="button" class="btn btn-secondary" onclick="addMenuItem()">新增菜單項目</button>
+    </div>
+
+    <div style="margin-top: 2rem;">
+        <button type="submit" class="btn btn-primary">送出</button>
+    </div>
+</form>
+
+<script>
+    let menuItemCount = 1;
+
+    function addMenuItem() {
+        const menuItems = document.getElementById('menu-items');
+        const newItem = document.createElement('div');
+        newItem.className = 'menu-item';
+        newItem.innerHTML = `
+            <input type="text" name="menu[${menuItemCount}][name]" class="form-input" placeholder="餐點名稱" required>
+            <input type="number" name="menu[${menuItemCount}][price]" class="form-input" placeholder="價格" step="0.01" required>
+            <select name="menu[${menuItemCount}][property]" class="form-input" required>
+                <option value="S">S</option>
+                <option value="M">M</option>
+                <option value="L">L</option>
+                <option value="份">份</option>
+            </select>
+            <button type="button" class="btn btn-danger" onclick="this.parentElement.remove()">刪除</button>
+        `;
+        menuItems.appendChild(newItem);
+        menuItemCount++;
+    }
+</script>

--- a/resources/views/Components/bandon-info.blade.php
+++ b/resources/views/Components/bandon-info.blade.php
@@ -102,7 +102,116 @@
         color: #666;
         padding: 20px;
     }
+
+    .store-info-section {
+        background-color: #f8f9fa;
+        padding: 25px;
+        border-radius: 10px;
+        margin-bottom: 30px;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+    }
+
+    .store-info-title {
+        font-size: 1.8em;
+        color: #2c3e50;
+        margin-bottom: 20px;
+        font-weight: 600;
+    }
+
+    .store-info-content {
+        display: grid;
+        gap: 15px;
+    }
+
+    .store-info-item {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+
+    .store-info-label {
+        font-weight: 600;
+        color: #666;
+        min-width: 80px;
+    }
+
+    .store-info-value {
+        color: #333;
+    }
+
+    .store-description {
+        margin-top: 20px;
+        padding: 15px;
+        background-color: #fff;
+        border-radius: 8px;
+        border-left: 4px solid #3498db;
+    }
+
+    .menu-section {
+        margin-top: 30px;
+    }
+
+    .menu-title {
+        font-size: 1.5em;
+        color: #2c3e50;
+        margin-bottom: 20px;
+        font-weight: 600;
+    }
+
+    .menu-table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 15px;
+        background-color: #fff;
+        border-radius: 8px;
+        overflow: hidden;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+    }
+
+    .menu-table th {
+        background-color: #f8f9fa;
+        padding: 12px 15px;
+        text-align: left;
+        font-weight: 600;
+        color: #2c3e50;
+        border-bottom: 2px solid #dee2e6;
+    }
+
+    .menu-table td {
+        padding: 12px 15px;
+        border-bottom: 1px solid #dee2e6;
+        color: #333;
+    }
+
+    .menu-table tr:last-child td {
+        border-bottom: none;
+    }
+
+    .menu-table tr:hover {
+        background-color: #f8f9fa;
+    }
+
+    .menu-name {
+        font-weight: 500;
+        color: #2c3e50;
+    }
+
+    .menu-property {
+        color: #666;
+    }
+
+    .menu-price {
+        font-weight: 500;
+        color: #e74c3c;
+        text-align: right;
+    }
 </style>
+
+<script>
+    @if(session('success'))
+    alert("{{ session('success') }}");
+    @endif
+</script>
 
 @if(isset($stores) && $stores->isNotEmpty())
 <div class="stores-container">
@@ -120,6 +229,50 @@
     </div>
     <div class="pagination-container">
         {{ $stores->links('pagination::bootstrap-4')  }}
+    </div>
+</div>
+@elseif(isset($storeInfo) && isset($menus) && $storeInfo && $menus->isNotEmpty())
+<div class="stores-container">
+    <div class="store-info-section">
+        <h1 class="store-info-title">{{ $storeInfo->name }}</h1>
+        <div class="store-info-content">
+            <div class="store-info-item">
+                <span class="store-info-label">電話：</span>
+                <span class="store-info-value">{{ $storeInfo->phone }}</span>
+            </div>
+            <div class="store-info-item">
+                <span class="store-info-label">地址：</span>
+                <span class="store-info-value">{{ $storeInfo->address }}</span>
+            </div>
+            @if($storeInfo->description)
+            <div class="store-description">
+                <div class="store-info-label">店家介紹：</div>
+                <div class="store-info-value">{{ $storeInfo->description }}</div>
+            </div>
+            @endif
+        </div>
+    </div>
+
+    <div class="menu-section">
+        <h2 class="menu-title">菜單列表</h2>
+        <table class="menu-table">
+            <thead>
+                <tr>
+                    <th>品項名稱</th>
+                    <th>份量</th>
+                    <th style="text-align: right;">價格</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach ($menus as $menu)
+                <tr>
+                    <td class="menu-name">{{ $menu->name }}</td>
+                    <td class="menu-property">{{ $menu->property }}</td>
+                    <td class="menu-price">$ {{ $menu->price ?? '無資料' }}</td>
+                </tr>
+                @endforeach
+            </tbody>
+        </table>
     </div>
 </div>
 @else

--- a/resources/views/Components/bandon-info.blade.php
+++ b/resources/views/Components/bandon-info.blade.php
@@ -213,6 +213,10 @@
     @endif
 </script>
 
+@php
+$hasAnyContent = false;
+@endphp
+
 @if(isset($stores) && $stores->isNotEmpty())
 <div class="stores-container">
     <h1 class="stores-title">商店清單</h1>
@@ -231,23 +235,25 @@
         {{ $stores->links('pagination::bootstrap-4')  }}
     </div>
 </div>
+@php $hasAnyContent = true; @endphp
 @elseif(isset($storeInfo) && isset($menus) && $storeInfo && $menus->isNotEmpty())
+@php $info = $storeInfo->first();@endphp
 <div class="stores-container">
     <div class="store-info-section">
-        <h1 class="store-info-title">{{ $storeInfo->name }}</h1>
+        <h1 class="store-info-title">{{ $info['name'] }}</h1>
         <div class="store-info-content">
             <div class="store-info-item">
                 <span class="store-info-label">電話：</span>
-                <span class="store-info-value">{{ $storeInfo->phone }}</span>
+                <span class="store-info-value">{{ $info['phone'] }}</span>
             </div>
             <div class="store-info-item">
                 <span class="store-info-label">地址：</span>
-                <span class="store-info-value">{{ $storeInfo->address }}</span>
+                <span class="store-info-value">{{ $info['address'] }}</span>
             </div>
-            @if($storeInfo->description)
+            @if($info['description'])
             <div class="store-description">
                 <div class="store-info-label">店家介紹：</div>
-                <div class="store-info-value">{{ $storeInfo->description }}</div>
+                <div class="store-info-value">{{ $info['description'] }}</div>
             </div>
             @endif
         </div>
@@ -266,15 +272,55 @@
             <tbody>
                 @foreach ($menus as $menu)
                 <tr>
-                    <td class="menu-name">{{ $menu->name }}</td>
-                    <td class="menu-property">{{ $menu->property }}</td>
-                    <td class="menu-price">$ {{ $menu->price ?? '無資料' }}</td>
+                    <td class="menu-name">{{ $menu['name'] }}</td>
+                    <td class="menu-property">{{ $menu['property'] }}</td>
+                    <td class="menu-price">$ {{ $menu['price'] ?? '無資料' }}</td>
                 </tr>
                 @endforeach
             </tbody>
         </table>
     </div>
 </div>
-@else
-<p class="no-stores">目前沒有店家資料</p>
+@php $hasAnyContent = true; @endphp
+@endif
+
+@if(isset($ownOrders) && $ownOrders->isNotEmpty())
+<div class="stores-container">
+    <h1 class="stores-title">{{ session('username') }} 開的團購單</h1>
+    <div class="stores-list">
+        @foreach ($ownOrders as $order)
+        <a href="/dinbandon/orders/{{ $order['order_id'] }}">
+            <div class="stores-item">
+                <div class="store-name">{{ $order['name'] }}</div>
+                <div class="store-phone">{{ $order['phone'] }}</div>
+                <div class="store-address">{{ $order['address'] ?? '無資料' }}</div>
+                <div class="store-address">結束時間：{{ $order['end_at'] ?? '無資料' }}</div>
+            </div>
+        </a>
+        @endforeach
+    </div>
+</div>
+@php $hasAnyContent = true; @endphp
+@endif
+@if(isset($orders) && $orders->isNotEmpty())
+<div class="stores-container">
+    <h1 class="stores-title">{{ session('username') }} 的團購單</h1>
+    <div class="stores-list">
+        @foreach ($orders as $order)
+        <a href="/dinbandon/orders/{{ $order['order_id'] }}">
+            <div class="stores-item">
+                <div class="store-name">{{ $order['name'] }}</div>
+                <div class="store-phone">{{ $order['phone'] }}</div>
+                <div class="store-address">{{ $order['address'] ?? '無資料' }}</div>
+                <div class="store-address">結束時間：{{ $order['end_at'] ?? '無資料' }}</div>
+            </div>
+        </a>
+        @endforeach
+    </div>
+</div>
+@php $hasAnyContent = true; @endphp
+@endif
+
+@if($hasAnyContent === false)
+<p class="no-stores">目前沒有資料</p>
 @endif

--- a/resources/views/Components/bandon-info.blade.php
+++ b/resources/views/Components/bandon-info.blade.php
@@ -1,128 +1,127 @@
 <style>
-    .tab-container {
-        width: 100%;
-        max-width: 1000px;
-        margin: 50px auto;
-        background-color: #fff;
-        border-radius: 8px;
-        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-    }
-
-    .tabs {
-        display: flex;
-        border-bottom: 2px solid #ddd;
-    }
-
-    .tab-button {
-        flex: 1;
-        padding: 15px;
-        text-align: center;
-        background-color: #f4f4f4;
-        border: none;
-        cursor: pointer;
-        transition: background-color 0.3s;
-    }
-
-    .tab-button:hover {
-        background-color: #e0e0e0;
-    }
-
-    .tab-button.active {
-        background-color: #007BFF;
-        color: #fff;
-    }
-
-    .tab-content {
-        display: none;
+    .stores-container {
+        max-width: 1200px;
+        margin: 0 auto;
         padding: 20px;
     }
 
-    .tab-content.active {
+    .stores-title {
+        margin-bottom: 20px;
+        color: #333;
+    }
+
+    .stores-list {
+        display: flex;
+        flex-direction: column;
+        gap: 15px;
+    }
+
+    .stores-item {
+        padding: 15px;
+        border: 1px solid #ddd;
+        border-radius: 8px;
+        background-color: #fff;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+
+    .store-name {
+        font-size: 1.2em;
+        margin-bottom: 8px;
+    }
+
+    .store-name a {
+        color: #2c3e50;
+        text-decoration: none;
+    }
+
+    .store-name a:hover {
+        color: #3498db;
+    }
+
+    .store-phone,
+    .store-address {
+        color: #666;
+        margin-top: 5px;
+    }
+
+    .pagination-container {
+        margin-top: 30px;
+        display: flex;
+        justify-content: center;
+    }
+
+    .pagination {
+        display: flex;
+        padding-left: 0;
+        list-style: none;
+        border-radius: 0.25rem;
+        margin: 0;
+    }
+
+    .page-item {
+        margin: 0 2px;
+    }
+
+    .page-link {
+        position: relative;
         display: block;
+        padding: 0.5rem 0.75rem;
+        margin-left: -1px;
+        line-height: 1.25;
+        color: #007bff;
+        background-color: #fff;
+        border: 1px solid #dee2e6;
+        text-decoration: none;
+    }
+
+    .page-item.active .page-link {
+        z-index: 3;
+        color: #fff;
+        background-color: #007bff;
+        border-color: #007bff;
+    }
+
+    .page-item.disabled .page-link {
+        color: #6c757d;
+        pointer-events: none;
+        cursor: auto;
+        background-color: #fff;
+        border-color: #dee2e6;
+    }
+
+    .page-link:hover {
+        z-index: 2;
+        color: #0056b3;
+        text-decoration: none;
+        background-color: #e9ecef;
+        border-color: #dee2e6;
+    }
+
+    .no-stores {
+        text-align: center;
+        color: #666;
+        padding: 20px;
     }
 </style>
-<script>
-    function switchTab(event, tabId) {
-        // 移除所有 tab 按鈕的 active 類
-        let buttons = document.querySelectorAll('.tab-button');
-        buttons.forEach(button => {
-            button.classList.remove('active');
-        });
 
-        // 顯示選中的 tab 內容並激活對應的 tab 按鈕
-        event.currentTarget.classList.add('active');
-
-        let contents = document.querySelectorAll('.tab-content');
-        contents.forEach(content => {
-            content.classList.remove('active');
-        });
-
-        document.getElementById(tabId).classList.add('active');
-    }
-</script>
-<div class="tab-container">
-    <div class="tabs">
-        <button class="tab-button active" onclick="switchTab(event, 'store-info-tab')">商家資訊</button>
-        <button class="tab-button" onclick="switchTab(event, 'order-info-tab')">訂購資訊</button>
-        <button class="tab-button" onclick="switchTab(event, 'new-store-tab')">新增店家</button>
-        <button class="tab-button" onclick="switchTab(event, 'new-order-tab')">團購去</button>
+@if(isset($stores) && $stores->isNotEmpty())
+<div class="stores-container">
+    <h1 class="stores-title">商店清單</h1>
+    <div class="stores-list">
+        @foreach ($stores as $store)
+        <a href="/dinbandon/stores/{{ $store->id }}">
+            <div class="stores-item">
+                <div class="store-name">{{ $store->name }}</div>
+                <div class="store-phone">{{ $store->phone }}</div>
+                <div class="store-address">{{ $store->address ?? '無資料' }}</div>
+            </div>
+        </a>
+        @endforeach
     </div>
-    <div id="store-info-tab" class="tab-content active">
-        <h2>商家資訊</h2>
-        <p>列出所有商家資訊。</p>
-    </div>
-    <div id="order-info-tab" class="tab-content">
-        <h2>訂購資訊</h2>
-        <p>列出還在時限內的所有團購單 ＆ 團購連結。</p>
-    </div>
-    <div id="new-store-tab" class="tab-content">
-        <h2>新增店家</h2>
-        <form action="" method="get" class="add-store-form">
-            <div>
-                <label for="name">店家名稱</label>
-                <input type="text" id="name" name="name">
-            </div>
-            <div>
-                <label for="name">簡介</label>
-                <input type="text" id="info" name="info">
-            </div>
-            <div>
-                <label for="name">電話</label>
-                <input type="text" id="phone" name="phone">
-            </div>
-            <div>
-                <label for="name">地址</label>
-                <input type="text" id="address" name="address">
-            </div>
-            <div>
-                <label for="name">產品</label>
-                <input type="text" id="product" name="product">
-            </div>
-            <div>
-                <input type="submit" value="Subscribe!" />
-            </div>
-        </form>
-    </div>
-    <div id="new-order-tab" class="tab-content">
-        <h2>團購去</h2>
-        <form action="" method="get" class="group-buy-form">
-            <div>
-                <label for="name">篩選</label>
-                <select>
-                    <option>請選擇</option>
-                </select>
-            </div>
-            <div>
-                <label for="name">負責人</label>
-                <input type="text" id="name" name="name">
-            </div>
-            <div>
-                <label for="name">截止時間</label>
-                <input type="text" id="end-time" name="end-time">
-            </div>
-            <div>
-                <input type="submit" value="Subscribe!" />
-            </div>
-        </form>
+    <div class="pagination-container">
+        {{ $stores->links('pagination::bootstrap-4')  }}
     </div>
 </div>
+@else
+<p class="no-stores">目前沒有店家資料</p>
+@endif

--- a/resources/views/Components/bandon-order.blade.php
+++ b/resources/views/Components/bandon-order.blade.php
@@ -1,0 +1,694 @@
+<style>
+    /* ... 您的 CSS 維持不變 ... */
+    .stores-container {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 20px;
+    }
+
+    .store-info-section {
+        background-color: #f8f9fa;
+        padding: 25px;
+        border-radius: 10px;
+        margin-bottom: 30px;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+    }
+
+    .store-info-title {
+        font-size: 1.8em;
+        color: #2c3e50;
+        margin-bottom: 20px;
+        font-weight: 600;
+    }
+
+    .store-info-content {
+        display: grid;
+        gap: 15px;
+    }
+
+    .store-info-item {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+
+    .store-info-label {
+        font-weight: 600;
+        color: #666;
+        min-width: 80px;
+    }
+
+    .store-info-value {
+        color: #333;
+    }
+
+    .store-description {
+        margin-top: 20px;
+        padding: 15px;
+        background-color: #fff;
+        border-radius: 8px;
+        border-left: 4px solid #3498db;
+    }
+
+    .menu-section {
+        margin-top: 30px;
+    }
+
+    .menu-title {
+        font-size: 1.5em;
+        color: #2c3e50;
+        margin-bottom: 20px;
+        font-weight: 600;
+    }
+
+    .menu-table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 15px;
+        background-color: #fff;
+        border-radius: 8px;
+        overflow: hidden;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+    }
+
+    .menu-table th {
+        background-color: #f8f9fa;
+        padding: 12px 15px;
+        text-align: left;
+        font-weight: 600;
+        color: #2c3e50;
+        border-bottom: 2px solid #dee2e6;
+    }
+
+    .menu-table td {
+        padding: 12px 15px;
+        border-bottom: 1px solid #dee2e6;
+        color: #333;
+    }
+
+    .menu-table tr:last-child td {
+        border-bottom: none;
+    }
+
+    .menu-table tr:hover {
+        background-color: #f8f9fa;
+    }
+
+    .menu-name {
+        font-weight: 500;
+        color: #2c3e50;
+    }
+
+    .menu-property {
+        color: #666;
+    }
+
+    .menu-price {
+        font-weight: 500;
+        color: #e74c3c;
+        text-align: right;
+    }
+
+    .modal {
+        display: none;
+        position: fixed;
+        z-index: 1;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+        overflow: auto;
+        background-color: rgba(0, 0, 0, 0.4);
+        justify-content: center;
+        align-items: center;
+    }
+
+    .modal-content {
+        background-color: #fefefe;
+        margin: auto;
+        padding: 20px;
+        border: 1px solid #888;
+        width: 80%;
+        max-width: 500px;
+        border-radius: 8px;
+        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+        position: relative;
+    }
+
+    .close-button {
+        color: #aaa;
+        float: right;
+        font-size: 28px;
+        font-weight: bold;
+        cursor: pointer;
+    }
+
+    .close-button:hover,
+    .close-button:focus {
+        color: black;
+        text-decoration: none;
+        cursor: pointer;
+    }
+
+    .modal-buttons {
+        text-align: right;
+        margin-top: 20px;
+    }
+
+    .modal-buttons button {
+        padding: 8px 15px;
+        border: none;
+        border-radius: 5px;
+        cursor: pointer;
+        font-size: 1em;
+    }
+
+    .modal-buttons .confirm-button {
+        background-color: #007bff;
+        color: white;
+    }
+
+    .modal-buttons .cancel-button {
+        background-color: #6c757d;
+        color: white;
+        margin-right: 10px;
+    }
+
+    .collapsible-title {
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding-right: 10px;
+    }
+
+    .toggle-icon {
+        font-size: 0.8em;
+        transition: transform 0.3s ease;
+    }
+
+    .toggle-icon.rotated {
+        transform: rotate(-90deg);
+    }
+
+    .collapsible-content.collapsed {
+        display: none;
+    }
+</style>
+
+@if(session('success'))
+<script>
+    alert("{{ session('success') }}");
+</script>
+@endif
+
+@php
+$hasAnyContent = false;
+@endphp
+
+<div class="stores-container">
+    <h2 class="menu-title collapsible-title" id="storeInfoAndMenuToggle">
+        店家資訊與菜單 <span class="toggle-icon">▼</span>
+    </h2>
+    <div class="collapsible-content" id="storeInfoAndMenuContent">
+        <div class="store-info-section">
+            <h1 class="store-info-title">{{ $responseData['storeInfo'][0]['name'] }}</h1>
+            <div class="store-info-content">
+                <div class="store-info-item">
+                    <span class="store-info-label">電話：</span>
+                    <span class="store-info-value">{{ $responseData['storeInfo'][0]['phone'] }}</span>
+                </div>
+                <div class="store-info-item">
+                    <span class="store-info-label">地址：</span>
+                    <span class="store-info-value">{{ $responseData['storeInfo'][0]['address'] }}</span>
+                </div>
+                @if(isset($responseData['storeInfo'][0]['description']))
+                <div class="store-description">
+                    <div class="store-info-label">店家介紹：</div>
+                    <div class="store-info-value">{{ $responseData['storeInfo'][0]['description'] }}</div>
+                </div>
+                @endif
+            </div>
+        </div>
+        @php $hasAnyContent = true; @endphp
+        @if(isset($responseData['storeMenu']) && $responseData['storeMenu']->isNotEmpty())
+        <div class="menu-section">
+            <h2 class="menu-title">菜單列表</h2>
+            <table class="menu-table">
+                <thead>
+                    <tr>
+                        <th>品項名稱</th>
+                        <th>份量</th>
+                        <th style="text-align: right;">價格</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($responseData['storeMenu'] as $menu)
+                    <tr>
+                        <td class="menu-name">{{ $menu['name'] }}</td>
+                        <td class="menu-property">{{ $menu['property'] }}</td>
+                        <td class="menu-price">$ {{ $menu['price'] ?? '無資料' }}</td>
+                    </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+        @php $hasAnyContent = true; @endphp
+        @endif
+    </div>
+
+    @if(isset($responseData['userOrder']))
+    <div class="menu-section">
+        <h2 class="menu-title">我的訂購</h2>
+        <form action="/dinbandon/orders/" method="POST">
+            @csrf
+            <input type="hidden" name="order_id" value="{{ $responseData['order_id'] ?? null}}">
+            <input type="hidden" name="store_id" value="{{ $responseData['store_id'] }}">
+            <table class="menu-table" id="myOrdersTable">
+                <thead>
+                    <tr>
+                        <th>品項名稱</th>
+                        <th>數量</th>
+                        <th>總價格</th>
+                        <th>是否已付款</th>
+                        <th>備註</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @if(isset($responseData['userOrder']['myOrderRecords']) && $responseData['userOrder']['myOrderRecords']->isNotEmpty())
+                    @foreach ($responseData['userOrder']['myOrderRecords'] as $record)
+                    <tr>
+                        <td class="menu-name">{{ $record['product_name'] }}</td>
+                        <td>
+                            <input type="number" name="orders[{{ $record['id'] }}][number]" value="{{ $record['number'] }}" min="1" class="form-control">
+                        </td>
+                        <td class="menu-price">$ {{ number_format($record['total_price'], 2) ?? '無資料' }}</td>
+                        <td>
+                            <input type="hidden" name="orders[{{ $record['id'] }}][is_paid]" value="{{ $record['is_paid'] ? 1 : 0 }}">
+                            {{ $record['is_paid'] ? '是' : '否' }}
+                        </td>
+                        <td class="menu-property">
+                            <input type="text" name="orders[{{ $record['id'] }}][description]" value="{{ $record['description'] }}" class="form-control">
+                        </td>
+                        <input type="hidden" name="orders[{{ $record['id'] }}][id]" value="{{ $record['id'] }}">
+                        <input type="hidden" name="orders[{{ $record['id'] }}][product_name]" value="{{ $record['product_name'] }}">
+                        <input type="hidden" name="orders[{{ $record['id'] }}][total_price]" value="{{ $record['total_price'] }}">
+                        <input type="hidden" name="orders[{{ $record['id'] }}][product_property]" value="{{ $record['product_property'] ?? '' }}">
+                    </tr>
+                    @endforeach
+                    @else
+                    <tr>
+                        <td colspan="5" style="text-align: center;">目前沒有您的訂單</td>
+                    </tr>
+                    @endif
+                </tbody>
+            </table>
+            <button type="submit" class="submit-all-orders-button">提交所有訂單變更</button>
+        </form>
+
+        <h3>新增訂單</h3>
+        <label for="product_name">品項名稱:</label><br>
+        <select id="product_name" name="product_name">
+            @if(isset($responseData['storeMenu']) && $responseData['storeMenu']->isNotEmpty())
+            @php
+            $uniqueProductNames = $responseData['storeMenu']->unique('name');
+            @endphp
+            @foreach ($uniqueProductNames as $menuItem)
+            <option value="{{ $menuItem['name'] }}">{{ $menuItem['name'] }}</option>
+            @endforeach
+            @else
+            <option value="">無可用菜單</option>
+            @endif
+        </select><br>
+        <label for="product_property">份量:</label><br>
+        <select id="product_property" name="product_property">
+            <option value="">請先選擇品項</option>
+        </select><br>
+        <label for="number">數量:</label><br>
+        <input type="number" id="number" name="number" value="1" min="1"><br>
+        <div>
+            <label for="price_display">單價:</label> <span id="price_display"></span>
+            <label for="total_price_display" style="margin-left: 20px;">總金額:</label> <span id="total_price_display"></span>
+        </div><br>
+        <label for="description">備註:</label><br>
+        <textarea id="description" name="description"></textarea><br>
+        <button type="submit" name="submit_action" value="create_unpaid">新增未付款訂單</button>
+        <input type="hidden" id="isPaidInput" name="is_paid" value="0">
+
+        <script>
+            // 將菜單資料儲存在客戶端，以便 JS 使用
+            const storeMenuData = <?php echo json_encode($responseData['storeMenu'] ?? []); ?>;
+
+            document.addEventListener('DOMContentLoaded', function() {
+                // --- DOM 元素 ---
+                const productSelect = document.getElementById('product_name');
+                const propertySelect = document.getElementById('product_property');
+                const priceDisplay = document.getElementById('price_display');
+                const numberInput = document.getElementById('number');
+                const totalPriceDisplay = document.getElementById('total_price_display');
+                const isPaidInput = document.getElementById('isPaidInput');
+                const createPaidButton = document.querySelector('button[name="submit_action"][value="create_paid"]');
+                const createUnpaidButton = document.querySelector('button[name="submit_action"][value="create_unpaid"]');
+                const myOrdersTbody = document.querySelector('#myOrdersTable tbody');
+
+                const editQuantityModal = document.getElementById('editQuantityModal');
+                const closeButton = editQuantityModal.querySelector('.close-button');
+                const cancelButton = editQuantityModal.querySelector('.cancel-button');
+                const editQuantityForm = document.getElementById('editQuantityForm');
+                const editProductNameInput = document.getElementById('editProductName');
+                const editProductPropertyInput = document.getElementById('editProductProperty');
+                const editQuantityInput = document.getElementById('editQuantity');
+                const editPriceDisplay = document.getElementById('editPriceDisplay');
+                const editTotalPriceDisplay = document.getElementById('editTotalPriceDisplay');
+
+                let currentOrderRow = null; // 追蹤正在被編輯的表格行 (<tr>)
+                let originalQuantity = 0; // 新增變數來儲存原始數量
+                let originalTotalPrice = 0; // 新增變數來儲存原始總價
+
+                // --- 函式 ---
+
+                // 獲取單一菜單項目的價格
+                function getMenuItemPrice(productName, productProperty) {
+                    const normalizedProductName = productName.trim().toLowerCase();
+                    const normalizedProductProperty = (productProperty || '').trim().toLowerCase();
+
+                    let selectedMenuItem = storeMenuData.find(menu => {
+                        const menuName = menu.name.trim().toLowerCase();
+                        const menuProperty = (menu.property || '').trim().toLowerCase();
+                        return menuName === normalizedProductName && menuProperty === normalizedProductProperty;
+                    });
+
+                    if (!selectedMenuItem && normalizedProductProperty === '') {
+                        const potentialMatchesByName = storeMenuData.filter(menu =>
+                            menu.name.trim().toLowerCase() === normalizedProductName
+                        );
+
+                        if (potentialMatchesByName.length === 1) {
+                            selectedMenuItem = potentialMatchesByName[0];
+                        } else if (potentialMatchesByName.length > 1) {
+                            selectedMenuItem = potentialMatchesByName.find(menu =>
+                                (menu.property || '').trim().toLowerCase() === ''
+                            );
+                        }
+                    }
+                    return selectedMenuItem && !isNaN(parseFloat(selectedMenuItem.price)) ? parseFloat(selectedMenuItem.price) : 0;
+                }
+
+                // [新增訂單] 填充份量選項
+                function populatePropertySelect(selectedProductName) {
+                    propertySelect.innerHTML = '';
+                    const filteredMenus = storeMenuData.filter(menu => menu.name === selectedProductName);
+                    const uniqueProperties = [...new Set(filteredMenus.map(menu => menu.property))];
+
+                    if (uniqueProperties.length > 0) {
+                        uniqueProperties.forEach(property => {
+                            const option = document.createElement('option');
+                            option.value = property;
+                            option.textContent = property;
+                            propertySelect.appendChild(option);
+                        });
+                        propertySelect.disabled = false;
+                    } else {
+                        propertySelect.innerHTML = '<option value="">無可用份量</option>';
+                        propertySelect.disabled = true;
+                    }
+                    updateNewOrderPriceDisplay();
+                }
+
+                // [新增訂單] 更新價格顯示
+                function updateNewOrderPriceDisplay() {
+                    const selectedProductName = productSelect.value;
+                    const selectedProperty = propertySelect.value;
+                    const number = parseInt(numberInput.value);
+
+                    const price = getMenuItemPrice(selectedProductName, selectedProperty);
+
+                    priceDisplay.textContent = price > 0 ? `$ ${price.toFixed(2)}` : '無資料';
+
+                    if (!isNaN(price) && !isNaN(number) && number >= 1) {
+                        totalPriceDisplay.textContent = `$ ${(price * number).toFixed(2)}`;
+                    } else {
+                        totalPriceDisplay.textContent = '請輸入有效數量';
+                    }
+                }
+
+                // [編輯訂單] 更新彈窗內的價格顯示
+                function updateEditPriceAndTotalDisplay() {
+                    const productName = editProductNameInput.value;
+                    const productProperty = editProductPropertyInput.value;
+                    const number = parseInt(editQuantityInput.value);
+
+                    const price = getMenuItemPrice(productName, productProperty);
+
+                    editPriceDisplay.textContent = price > 0 ? `$ ${price.toFixed(2)}` : '查無單價';
+
+                    if (!isNaN(price) && price > 0 && !isNaN(number) && number >= 1) {
+                        editTotalPriceDisplay.textContent = `$ ${(price * number).toFixed(2)}`;
+                    } else {
+                        editTotalPriceDisplay.textContent = '無法計算';
+                    }
+                }
+
+                // --- 事件監聽器 ---
+
+                // [新增訂單] 初始化與事件綁定
+                if (productSelect.value) {
+                    populatePropertySelect(productSelect.value);
+                } else {
+                    updateNewOrderPriceDisplay();
+                }
+                productSelect.addEventListener('change', () => populatePropertySelect(productSelect.value));
+                propertySelect.addEventListener('change', updateNewOrderPriceDisplay);
+                numberInput.addEventListener('input', updateNewOrderPriceDisplay);
+
+                // [我的訂購] 監聽數量變化並更新總價格
+                const myOrdersTable = document.getElementById('myOrdersTable');
+                if (myOrdersTable) {
+                    myOrdersTable.addEventListener('input', function(event) {
+                        // 檢查事件目標是否為數量輸入框 (名稱包含 [number])
+                        if (event.target.matches('input[name*="[number]"]')) {
+                            const quantityInput = event.target;
+                            const newQuantity = parseInt(quantityInput.value);
+
+                            // 確保數量為有效數字且大於等於 1
+                            if (isNaN(newQuantity) || newQuantity < 1) {
+                                // 可以選擇在此處處理無效輸入，例如重置為 1 或顯示錯誤訊息
+                                return;
+                            }
+
+                            const row = quantityInput.closest('tr'); // 獲取當前行
+                            // 從輸入框的 name 屬性中提取 orderId (例如從 orders[123][number] 中提取 123)
+                            const orderIdMatch = quantityInput.name.match(/orders\[(.*?)\]\[number\]/);
+                            const orderId = orderIdMatch ? orderIdMatch[1] : null;
+
+                            if (row && orderId) {
+                                // 從同行的隱藏輸入框中獲取 product_name 和 product_property
+                                const productNameInput = row.querySelector(`input[name="orders[${orderId}][product_name]"]`);
+                                const productPropertyInput = row.querySelector(`input[name="orders[${orderId}][product_property]"]`);
+
+                                const productName = productNameInput ? productNameInput.value : '';
+                                const productProperty = productPropertyInput ? productPropertyInput.value : '';
+
+                                // 使用現有的 getMenuItemPrice 函式獲取單價
+                                const unitPrice = getMenuItemPrice(productName, productProperty);
+                                // 計算新的總價格
+                                const newTotalPrice = (unitPrice * newQuantity).toFixed(2);
+
+                                // 更新顯示的總價格
+                                const priceDisplayTd = row.querySelector('.menu-price');
+                                if (priceDisplayTd) {
+                                    priceDisplayTd.textContent = `$ ${newTotalPrice}`;
+                                }
+
+                                // 更新隱藏的 total_price 輸入框的值 (以便表單提交時傳遞正確的總價)
+                                const hiddenTotalPriceInput = row.querySelector(`input[name="orders[${orderId}][total_price]"]`);
+                                if (hiddenTotalPriceInput) {
+                                    hiddenTotalPriceInput.value = newTotalPrice;
+                                }
+                            }
+                        }
+                    });
+                }
+
+                // [新增訂單] 處理「新增未付款訂單」按鈕的點擊事件 (純前端更新)
+                if (createUnpaidButton) {
+                    createUnpaidButton.addEventListener('click', function(event) {
+                        event.preventDefault(); // 阻止表單的預設提交行為
+
+                        const productName = productSelect.value;
+                        const productProperty = propertySelect.value;
+                        const number = parseInt(numberInput.value);
+                        const description = document.getElementById('description').value;
+
+                        // HTML 實體編碼描述，防止 XSS 和破壞 HTML 結構
+                        const encodedDescription = document.createElement('div');
+                        encodedDescription.textContent = description;
+                        const safeDescription = encodedDescription.innerHTML;
+
+                        const price = getMenuItemPrice(productName, productProperty);
+                        const totalPrice = (price * number).toFixed(2); // 計算總金額
+
+                        // For newly added rows, we need a temporary unique ID
+                        const tempOrderId = `temp_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
+
+                        // 創建新的表格行
+                        const newRow = document.createElement('tr');
+                        newRow.innerHTML = `
+                            <td class="menu-name">${productName}</td>
+                            <td>
+                                <input type="number" name="orders[${tempOrderId}][number]" value="${number}" min="1" class="form-control">
+                            </td>
+                            <td class="menu-price">$ ${totalPrice}</td>
+                            <td>
+                                <input type="hidden" name="orders[${tempOrderId}][is_paid]" value="0">
+                                否
+                            </td>
+                            <td class="menu-property">
+                                <input type="text" name="orders[${tempOrderId}][description]" value="${safeDescription}" class="form-control">
+                            </td>
+                            <input type="hidden" name="orders[${tempOrderId}][id]" value="${tempOrderId}">
+                            <input type="hidden" name="orders[${tempOrderId}][product_name]" value="${productName}">
+                            <input type="hidden" name="orders[${tempOrderId}][total_price]" value="${totalPrice}">
+                            <input type="hidden" name="orders[${tempOrderId}][product_property]" value="${productProperty}">
+                        `;
+
+                        // 檢查是否有「目前沒有您的訂單」的提示行，如果有則移除
+                        const noOrderRow = myOrdersTbody.querySelector('tr > td[colspan="5"]');
+                        if (noOrderRow) {
+                            noOrderRow.closest('tr').remove();
+                        }
+
+                        // 將新行添加到表格中
+                        myOrdersTbody.appendChild(newRow);
+
+                        // 清空表單
+                        productSelect.value = storeMenuData.length > 0 ? storeMenuData[0].name : '';
+                        populatePropertySelect(productSelect.value); // 重新填充份量選項
+                        numberInput.value = '1';
+                        document.getElementById('description').value = '';
+                        updateNewOrderPriceDisplay(); // 更新價格顯示
+                    });
+                }
+
+                // [編輯訂單] 點擊 "編輯" 按鈕 (使用事件委派)
+                myOrdersTbody.addEventListener('click', function(event) {
+                    const button = event.target.closest('.edit-order-button');
+                    if (button) {
+                        currentOrderRow = button.closest('tr');
+
+                        const productName = button.getAttribute('data-product-name');
+                        const productProperty = button.getAttribute('data-product-property');
+                        const currentQuantityStr = button.getAttribute('data-current-quantity');
+
+                        // 擷取原始數量和總價
+                        originalQuantity = parseInt(currentQuantityStr);
+                        // 從表格的第三個<td>（索引為2）獲取總價文本，去除'$'並解析為浮點數
+                        const originalTotalPriceText = currentOrderRow.children[2].textContent;
+                        originalTotalPrice = parseFloat(originalTotalPriceText.replace('$', '').trim());
+
+                        editProductNameInput.value = productName;
+                        editProductPropertyInput.value = productProperty;
+                        editQuantityInput.value = currentQuantityStr;
+
+                        editQuantityModal.style.display = 'flex';
+                        // 打開彈窗時立即更新一次價格
+                        updateEditPriceAndTotalDisplay();
+                    }
+                });
+
+                // [編輯訂單] 在彈窗中修改數量時，即時更新總價
+                editQuantityInput.addEventListener('input', updateEditPriceAndTotalDisplay);
+
+                // [編輯訂單] 關閉彈窗
+                closeButton.addEventListener('click', () => editQuantityModal.style.display = 'none');
+                cancelButton.addEventListener('click', () => editQuantityModal.style.display = 'none');
+                window.addEventListener('click', (event) => {
+                    if (event.target === editQuantityModal) {
+                        editQuantityModal.style.display = 'none';
+                    }
+                });
+
+                // [編輯訂單] 處理表單提交 (純前端更新)
+                editQuantityForm.addEventListener('submit', function(event) {
+                    event.preventDefault();
+
+                    const newQuantity = parseInt(editQuantityInput.value);
+                    const newTotalPriceText = editTotalPriceDisplay.textContent;
+                    const newTotalPrice = parseFloat(newTotalPriceText.replace('$', '').trim());
+
+                    // 從 currentOrderRow 中找到編輯按鈕以獲取 orderId
+                    const editButtonInRow = currentOrderRow.querySelector('.edit-order-button');
+                    const orderId = editButtonInRow ? editButtonInRow.getAttribute('data-order-id') : null;
+
+                    // 檢查數量和總金額是否有實際變動
+                    if (newQuantity === originalQuantity && newTotalPrice.toFixed(2) === originalTotalPrice.toFixed(2)) {
+                        alert('沒有任何變更，無需更新。');
+                        editQuantityModal.style.display = 'none';
+                        return; // 退出函式，因為無需更新
+                    }
+
+                    // 確保有找到價格才能更新
+                    if (currentOrderRow && newTotalPriceText !== '無法計算' && newTotalPriceText !== '查無單價' && !isNaN(newTotalPrice) && newTotalPrice >= 0) {
+                        // 更新表格中的數量和總價
+                        currentOrderRow.children[1].textContent = newQuantity;
+                        currentOrderRow.children[2].textContent = newTotalPriceText;
+
+                        // 更新按鈕上的 data-屬性，以便下次編輯
+                        if (editButtonInRow) {
+                            editButtonInRow.setAttribute('data-current-quantity', newQuantity);
+                        }
+
+                        editQuantityModal.style.display = 'none';
+
+                    } else {
+                        alert('無法更新，因為價格計算無效或找不到對應的菜單項目。');
+                    }
+                });
+
+                // [通用] 可折疊區塊功能
+                const storeInfoAndMenuToggle = document.getElementById('storeInfoAndMenuToggle');
+                const storeInfoAndMenuContent = document.getElementById('storeInfoAndMenuContent');
+                const toggleIcon = storeInfoAndMenuToggle.querySelector('.toggle-icon');
+
+                if (storeInfoAndMenuToggle) {
+                    storeInfoAndMenuToggle.addEventListener('click', function() {
+                        storeInfoAndMenuContent.classList.toggle('collapsed');
+                        toggleIcon.classList.toggle('rotated');
+                    });
+                }
+            });
+        </script>
+    </div>
+    @php $hasAnyContent = true; @endphp
+    @endif
+
+    @if(isset($responseData['userOrder']) && isset($responseData['userOrder']['otherParticipantsRecords']) && $responseData['userOrder']['otherParticipantsRecords']->isNotEmpty())
+    @php $hasAnyContent = true; @endphp
+    @endif
+
+    @if($hasAnyContent === false)
+    <p>目前沒有資料</p>
+    @endif
+</div>
+<!-- Edit Quantity Modal -->
+<div id="editQuantityModal" class="modal">
+    <div class="modal-content">
+        <span class="close-button">×</span>
+        <h2>修改訂單數量</h2>
+        <!-- 移除 onsubmit="return false;"，由 JS event listener 控制 -->
+        <form id="editQuantityForm">
+            <input type="hidden" id="editProductName" name="product_name">
+            <input type="hidden" id="editProductProperty" name="product_property">
+            <label for="editQuantity">數量:</label>
+            <input type="number" id="editQuantity" name="number" min="1" required style="width: 100%; padding: 8px; margin-top: 5px; margin-bottom: 15px;">
+            <div>
+                <span>單價: </span><span id="editPriceDisplay" style="font-weight: bold;"></span>
+                <span style="margin-left: 20px;">總金額: </span><span id="editTotalPriceDisplay" style="font-weight: bold; color: #e74c3c;"></span>
+            </div>
+            <div class="modal-buttons">
+                <button type="button" class="cancel-button">取消</button>
+                <button type="submit" class="confirm-button">更新</button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/resources/views/Components/bandon-order.blade.php
+++ b/resources/views/Components/bandon-order.blade.php
@@ -260,8 +260,9 @@ $hasAnyContent = false;
     @if(isset($responseData['userOrder']))
     <div class="menu-section">
         <h2 class="menu-title">我的訂購</h2>
-        <form action="/dinbandon/orders/" method="POST">
+        <form action="/dinbandon/orders/{{ $responseData['order_id'] }}" method="POST">
             @csrf
+            @method('PATCH')
             <input type="hidden" name="order_id" value="{{ $responseData['order_id'] ?? null}}">
             <input type="hidden" name="store_id" value="{{ $responseData['store_id'] }}">
             <table class="menu-table" id="myOrdersTable">

--- a/resources/views/Components/bandon-order.blade.php
+++ b/resources/views/Components/bandon-order.blade.php
@@ -290,13 +290,12 @@ $hasAnyContent = false;
                             {{ $record['is_paid'] ? '是' : '否' }}
                         </td>
                         <td>{{ $record['property'] ?? '無資料' }}</td>
-                        <td class="menu-property">
-                            <input type="text" name="orders[{{ $record['id'] }}][description]" value="{{ $record['description'] }}" class="form-control">
-                        </td>
+                        <td class="menu-property">{{ $record['description'] ?? '無備註' }}</td>
                         <input type="hidden" name="orders[{{ $record['id'] }}][id]" value="{{ $record['id'] }}">
                         <input type="hidden" name="orders[{{ $record['id'] }}][product_name]" value="{{ $record['product_name'] }}">
                         <input type="hidden" name="orders[{{ $record['id'] }}][total_price]" value="{{ $record['total_price'] }}">
                         <input type="hidden" name="orders[{{ $record['id'] }}][product_property]" value="{{ $record['property'] }}">
+                        <input type="hidden" name="orders[{{ $record['id'] }}][description]" value="{{ $record['description'] }}">
                     </tr>
                     @endforeach
                     @else

--- a/resources/views/Components/bandon-order.blade.php
+++ b/resources/views/Components/bandon-order.blade.php
@@ -271,6 +271,7 @@ $hasAnyContent = false;
                         <th>數量</th>
                         <th>總價格</th>
                         <th>是否已付款</th>
+                        <th>份量</th>
                         <th>備註</th>
                     </tr>
                 </thead>
@@ -287,18 +288,18 @@ $hasAnyContent = false;
                             <input type="hidden" name="orders[{{ $record['id'] }}][is_paid]" value="{{ $record['is_paid'] ? 1 : 0 }}">
                             {{ $record['is_paid'] ? '是' : '否' }}
                         </td>
+                        <td>{{ $record['property'] ?? '無資料' }}</td>
                         <td class="menu-property">
                             <input type="text" name="orders[{{ $record['id'] }}][description]" value="{{ $record['description'] }}" class="form-control">
                         </td>
                         <input type="hidden" name="orders[{{ $record['id'] }}][id]" value="{{ $record['id'] }}">
                         <input type="hidden" name="orders[{{ $record['id'] }}][product_name]" value="{{ $record['product_name'] }}">
                         <input type="hidden" name="orders[{{ $record['id'] }}][total_price]" value="{{ $record['total_price'] }}">
-                        <input type="hidden" name="orders[{{ $record['id'] }}][product_property]" value="{{ $record['product_property'] ?? '' }}">
                     </tr>
                     @endforeach
                     @else
                     <tr>
-                        <td colspan="5" style="text-align: center;">目前沒有您的訂單</td>
+                        <td colspan="6" style="text-align: center;">目前沒有您的訂單</td>
                     </tr>
                     @endif
                 </tbody>
@@ -543,6 +544,7 @@ $hasAnyContent = false;
                                 <input type="hidden" name="orders[${tempOrderId}][is_paid]" value="0">
                                 否
                             </td>
+                            <td>${productProperty}</td>
                             <td class="menu-property">
                                 <input type="text" name="orders[${tempOrderId}][description]" value="${safeDescription}" class="form-control">
                             </td>
@@ -553,7 +555,7 @@ $hasAnyContent = false;
                         `;
 
                         // 檢查是否有「目前沒有您的訂單」的提示行，如果有則移除
-                        const noOrderRow = myOrdersTbody.querySelector('tr > td[colspan="5"]');
+                        const noOrderRow = myOrdersTbody.querySelector('tr > td[colspan="6"]');
                         if (noOrderRow) {
                             noOrderRow.closest('tr').remove();
                         }

--- a/resources/views/Components/bandon-order.blade.php
+++ b/resources/views/Components/bandon-order.blade.php
@@ -295,6 +295,7 @@ $hasAnyContent = false;
                         <input type="hidden" name="orders[{{ $record['id'] }}][id]" value="{{ $record['id'] }}">
                         <input type="hidden" name="orders[{{ $record['id'] }}][product_name]" value="{{ $record['product_name'] }}">
                         <input type="hidden" name="orders[{{ $record['id'] }}][total_price]" value="{{ $record['total_price'] }}">
+                        <input type="hidden" name="orders[{{ $record['id'] }}][product_property]" value="{{ $record['property'] }}">
                     </tr>
                     @endforeach
                     @else

--- a/resources/views/Components/bandon-orderlist.blade.php
+++ b/resources/views/Components/bandon-orderlist.blade.php
@@ -1,0 +1,264 @@
+<style>
+    .stores-container {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 20px;
+    }
+
+    .stores-title {
+        margin-bottom: 20px;
+        color: #333;
+    }
+
+    .stores-list {
+        display: flex;
+        flex-direction: column;
+        gap: 15px;
+    }
+
+    .stores-item {
+        padding: 15px;
+        border: 1px solid #ddd;
+        border-radius: 8px;
+        background-color: #fff;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+
+    .store-name {
+        font-size: 1.2em;
+        margin-bottom: 8px;
+    }
+
+    .store-name a {
+        color: #2c3e50;
+        text-decoration: none;
+    }
+
+    .store-name a:hover {
+        color: #3498db;
+    }
+
+    .store-phone,
+    .store-address {
+        color: #666;
+        margin-top: 5px;
+    }
+
+    .pagination-container {
+        margin-top: 30px;
+        display: flex;
+        justify-content: center;
+    }
+
+    .pagination {
+        display: flex;
+        padding-left: 0;
+        list-style: none;
+        border-radius: 0.25rem;
+        margin: 0;
+    }
+
+    .page-item {
+        margin: 0 2px;
+    }
+
+    .page-link {
+        position: relative;
+        display: block;
+        padding: 0.5rem 0.75rem;
+        margin-left: -1px;
+        line-height: 1.25;
+        color: #007bff;
+        background-color: #fff;
+        border: 1px solid #dee2e6;
+        text-decoration: none;
+    }
+
+    .page-item.active .page-link {
+        z-index: 3;
+        color: #fff;
+        background-color: #007bff;
+        border-color: #007bff;
+    }
+
+    .page-item.disabled .page-link {
+        color: #6c757d;
+        pointer-events: none;
+        cursor: auto;
+        background-color: #fff;
+        border-color: #dee2e6;
+    }
+
+    .page-link:hover {
+        z-index: 2;
+        color: #0056b3;
+        text-decoration: none;
+        background-color: #e9ecef;
+        border-color: #dee2e6;
+    }
+
+    .no-stores {
+        text-align: center;
+        color: #666;
+        padding: 20px;
+    }
+
+    .modal {
+        display: none;
+        position: fixed;
+        z-index: 1000;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+        background-color: rgba(0, 0, 0, 0.5);
+    }
+
+    .modal-content {
+        background-color: #fefefe;
+        margin: 15% auto;
+        padding: 20px;
+        border: 1px solid #888;
+        width: 80%;
+        max-width: 600px;
+        border-radius: 8px;
+        position: relative;
+    }
+
+    .close {
+        color: #aaa;
+        float: right;
+        font-size: 28px;
+        font-weight: bold;
+        cursor: pointer;
+    }
+
+    .close:hover {
+        color: black;
+    }
+
+    .modal-iframe {
+        width: 100%;
+        height: 500px;
+        border: none;
+    }
+
+    .post-button {
+        padding: 5px 15px;
+        background-color: #4CAF50;
+        color: white;
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 14px;
+        margin-left: 10px;
+    }
+
+    .post-button:hover {
+        background-color: #45a049;
+    }
+
+    .time-inputs {
+        display: flex;
+        flex-direction: column;
+        gap: 5px;
+        margin-right: 10px;
+    }
+
+    .time-input {
+        padding: 5px;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        font-size: 14px;
+    }
+
+    .time-label {
+        color: #666;
+        font-size: 14px;
+        white-space: nowrap;
+    }
+
+    .time-group {
+        display: flex;
+        align-items: center;
+        gap: 5px;
+    }
+</style>
+
+<script>
+    @if(session('success'))
+    alert("{{ session('success') }}");
+    @endif
+
+    function openStoreModal(storeId) {
+        var modal = document.getElementById('storeModal');
+        var iframe = document.getElementById('storeIframe');
+        iframe.src = '/dinbandon/stores/' + storeId;
+        modal.style.display = "block";
+    }
+
+    function closeStoreModal() {
+        var modal = document.getElementById('storeModal');
+        modal.style.display = "none";
+    }
+
+    // 點擊 modal 外部時關閉
+    window.onclick = function(event) {
+        var modal = document.getElementById('storeModal');
+        if (event.target == modal) {
+            modal.style.display = "none";
+        }
+    }
+</script>
+
+@php
+$hasAnyContent = false;
+@endphp
+
+@if(isset($stores) && $stores->isNotEmpty())
+<div class="stores-container">
+    <h1 class="stores-title">商店清單</h1>
+    <div class="stores-list">
+        @foreach ($stores as $store)
+        <div class="stores-item" style="display: flex; align-items: center; justify-content: space-between;">
+            <div onclick="openStoreModal({{ $store->id }})" style="cursor: pointer; flex: 1;">
+                <div class="store-name">{{ $store->name }}</div>
+                <div class="store-phone">{{ $store->phone }}</div>
+                <div class="store-address">{{ $store->address ?? '無資料' }}</div>
+            </div>
+            <form action="/dinbandon/orders" method="POST" style="margin: 0; display: flex; align-items: center;">
+                @csrf
+                <input type="hidden" name="store_id" value="{{ $store->id }}">
+                <div class="time-inputs">
+                    <div class="time-group">
+                        <span class="time-label">開始：</span>
+                        <input type="datetime-local" name="start_time" class="time-input" required>
+                    </div>
+                    <div class="time-group">
+                        <span class="time-label">結束：</span>
+                        <input type="datetime-local" name="end_time" class="time-input" required>
+                    </div>
+                </div>
+                <button type="submit" class="post-button">建立新團購單</button>
+            </form>
+        </div>
+        @endforeach
+    </div>
+    <div class="pagination-container">
+        {{ $stores->links('pagination::bootstrap-4')  }}
+    </div>
+</div>
+
+<!-- Modal -->
+<div id="storeModal" class="modal">
+    <div class="modal-content">
+        <span class="close" onclick="closeStoreModal()">&times;</span>
+        <iframe id="storeIframe" class="modal-iframe"></iframe>
+    </div>
+</div>
+@php $hasAnyContent = true; @endphp
+@endif
+
+@if($hasAnyContent === false)
+<p class="no-stores">目前沒有資料</p>
+@endif

--- a/resources/views/Components/layout.blade.php
+++ b/resources/views/Components/layout.blade.php
@@ -271,9 +271,9 @@
                     <a href="/dinbandon" class="dropbtn">DingBanDon</a>
                     <div class="dropdown-content">
                         <a href="/dinbandon/stores">商店資訊</a>
-                        <a href="/dinbandon/addstores">新增店家</a>
+                        <a href="/dinbandon/store/create">新增店家</a>
                         <a href="/dinbandon/orders">訂單頁面</a>
-                        <a href="/dinbandon/addorders">新增order</a>
+                        <a href="/dinbandon/order/create">新增order</a>
                     </div>
                 </li>
                 <li><a href="/meetings">MeetingRoom</a></li>

--- a/resources/views/Components/layout.blade.php
+++ b/resources/views/Components/layout.blade.php
@@ -58,6 +58,7 @@
 
         .menu li {
             float: left;
+            position: relative;
         }
 
         .menu a {
@@ -70,6 +71,38 @@
         }
 
         .menu a:hover {
+            background-color: #ffc078;
+            color: #333;
+        }
+
+        /* Dropdown Styles */
+        .dropdown-content {
+            display: none;
+            position: absolute;
+            background-color: #333;
+            min-width: 160px;
+            box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
+            z-index: 1;
+        }
+
+        .dropdown-content a {
+            color: #ffc078;
+            padding: 12px 16px;
+            text-decoration: none;
+            display: block;
+            line-height: 1.5;
+        }
+
+        .dropdown-content a:hover {
+            background-color: #ffc078;
+            color: #333;
+        }
+
+        .dropdown:hover .dropdown-content {
+            display: block;
+        }
+
+        .dropdown:hover .dropbtn {
             background-color: #ffc078;
             color: #333;
         }
@@ -234,7 +267,15 @@
 
             <ul class="menu">
                 @auth
-                <li><a href="/dinbandon">DingBanDon</a></li>
+                <li class="dropdown">
+                    <a href="/dinbandon" class="dropbtn">DingBanDon</a>
+                    <div class="dropdown-content">
+                        <a href="/dinbandon/stores">商店資訊</a>
+                        <a href="/dinbandon/addstores">新增店家</a>
+                        <a href="/dinbandon/orders">訂單頁面</a>
+                        <a href="/dinbandon/addorders">新增order</a>
+                    </div>
+                </li>
                 <li><a href="/meetings">MeetingRoom</a></li>
                 @endauth
                 @guest

--- a/resources/views/Components/menu-list.blade.php
+++ b/resources/views/Components/menu-list.blade.php
@@ -1,0 +1,21 @@
+<div class="menu-section">
+    <h2 class="menu-title">菜單列表</h2>
+    <table class="menu-table">
+        <thead>
+            <tr>
+                <th>品項名稱</th>
+                <th>份量</th>
+                <th style="text-align: right;">價格</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($storeMenu as $menu)
+            <tr>
+                <td class="menu-name">{{ $menu['name'] }}</td>
+                <td class="menu-property">{{ $menu['property'] }}</td>
+                <td class="menu-price">$ {{ $menu['price'] ?? '無資料' }}</td>
+            </tr>
+            @endforeach
+        </tbody>
+    </table>
+</div>

--- a/resources/views/Components/my-orders.blade.php
+++ b/resources/views/Components/my-orders.blade.php
@@ -1,0 +1,71 @@
+<div class="menu-section">
+    <h2 class="menu-title">我的訂購</h2>
+    <table class="menu-table">
+        <thead>
+            <tr>
+                <th>品項名稱</th>
+                <th>數量</th>
+                <th>總價格</th>
+                <th>是否已付款</th>
+                <th>備註</th>
+                <th>操作</th>
+            </tr>
+        </thead>
+        <tbody>
+            @if(isset($userOrder['myOrderRecords']) && $userOrder['myOrderRecords']->isNotEmpty())
+            @foreach ($userOrder['myOrderRecords'] as $record)
+            <tr>
+                <td class="menu-name">{{ $record['product_name'] }}</td>
+                <td class="menu-property">{{ $record['number'] }}</td>
+                <td class="menu-price">$ {{ $record['total_price'] ?? '無資料' }}</td>
+                <td>{{ $record['is_paid'] ? '是' : '否' }}</td>
+                <td class="menu-property">{{ $record['description'] }}</td>
+                <td>
+                    <button>編輯</button>
+                    <form action="/orders/{{ $record['id'] }}" method="POST" style="display:inline;">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" onclick="return confirm('確定要刪除這筆訂單嗎？')">刪除</button>
+                    </form>
+                </td>
+            </tr>
+            @endforeach
+            @else
+            <tr>
+                <td colspan="6" style="text-align: center;">目前沒有您的訂單</td>
+            </tr>
+            @endif
+        </tbody>
+    </table>
+    <h3>新增訂單</h3>
+    <form>
+        <label for="product_name">品項名稱:</label><br>
+        <select id="product_name" name="product_name">
+            @if(isset($storeMenu) && $storeMenu->isNotEmpty())
+            @foreach ($storeMenu as $menu)
+            <option value="{{ $menu['name'] }}">{{ $menu['name'] }}</option>
+            @endforeach
+            @else
+            <option value="">無可用菜單</option>
+            @endif
+        </select><br>
+        <label for="product_property">份量:</label><br>
+        <select id="product_property" name="product_property">
+            <option value="">請先選擇品項</option>
+        </select><br>
+        <label for="number">數量:</label><br>
+        <input type="number" id="number" name="number" value="1" min="1"><br>
+        <div>
+            <label for="price_display">單價:</label> <span id="price_display"></span>
+            <label for="total_price_display" style="margin-left: 20px;">總金額:</label> <span id="total_price_display"></span>
+        </div><br>
+        <label for="description">備註:</label><br>
+        <textarea id="description" name="description"></textarea><br>
+        <input type="submit" value="送出">
+    </form>
+
+    <script>
+        const storeMenuData = <?php echo json_encode($storeMenu); ?>;
+    </script>
+    <script src="{{ asset('js/bandon-order.js') }}"></script>
+</div>

--- a/resources/views/Components/other-participants-orders.blade.php
+++ b/resources/views/Components/other-participants-orders.blade.php
@@ -1,0 +1,27 @@
+<div class="menu-section">
+    <h2 class="menu-title">其他人的訂單</h2>
+    <table class="menu-table">
+        <thead>
+            <tr>
+                <th>使用者名稱</th>
+                <th>品項名稱</th>
+                <th>數量</th>
+                <th>總價格</th>
+                <th>是否已付款</th>
+                <th>備註</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($otherParticipantsRecords as $record)
+            <tr>
+                <td class="menu-name">{{ $record['user_name'] }}</td>
+                <td class="menu-name">{{ $record['product_name'] }}</td>
+                <td class="menu-property">{{ $record['number'] }}</td>
+                <td class="menu-price">$ {{ $record['total_price'] ?? '無資料' }}</td>
+                <td>{{ $record['is_paid'] ? '是' : '否' }}</td>
+                <td class="menu-property">{{ $record['description'] }}</td>
+            </tr>
+            @endforeach
+        </tbody>
+    </table>
+</div>

--- a/resources/views/Components/store-info.blade.php
+++ b/resources/views/Components/store-info.blade.php
@@ -1,0 +1,19 @@
+<div class="store-info-section">
+    <h1 class="store-info-title">{{ $storeInfo[0]['name'] }}</h1>
+    <div class="store-info-content">
+        <div class="store-info-item">
+            <span class="store-info-label">電話：</span>
+            <span class="store-info-value">{{ $storeInfo[0]['phone'] }}</span>
+        </div>
+        <div class="store-info-item">
+            <span class="store-info-label">地址：</span>
+            <span class="store-info-value">{{ $storeInfo[0]['address'] }}</span>
+        </div>
+        @if(isset($storeInfo[0]['description']))
+        <div class="store-description">
+            <div class="store-info-label">店家介紹：</div>
+            <div class="store-info-value">{{ $storeInfo[0]['description'] }}</div>
+        </div>
+        @endif
+    </div>
+</div>

--- a/resources/views/add-order.blade.php
+++ b/resources/views/add-order.blade.php
@@ -1,0 +1,6 @@
+<x-layout>
+    <x-slot:productName>
+        DinBanDon-add group buy
+    </x-slot:productName>
+    <x-components.bandon-orderlist :stores='$stores'></x-components.bandon-orderlist>
+</x-layout>

--- a/resources/views/add-store.blade.php
+++ b/resources/views/add-store.blade.php
@@ -1,0 +1,11 @@
+<x-layout>
+    <x-slot:productName>
+        Add BanDon Store
+    </x-slot:productName>
+
+    <div class="container mx-auto px-4 py-8">
+        <div class="max-w-4xl mx-auto">
+            <x-components.bandon-form></x-components.bandon-form>
+        </div>
+    </div>
+</x-layout>

--- a/resources/views/all-bandon.blade.php
+++ b/resources/views/all-bandon.blade.php
@@ -1,0 +1,6 @@
+<x-layout>
+    <x-slot:productName>
+        DinBanDon
+    </x-slot:productName>
+    <x-components.bandon-info :stores="$stores"></x-components.bandon-info>
+</x-layout>

--- a/resources/views/bandon.blade.php
+++ b/resources/views/bandon.blade.php
@@ -2,5 +2,5 @@
     <x-slot:productName>
         DinBanDon
     </x-slot:productName>
-    <x-components.bandon-info></x-components.bandon-info>
+    <x-components.bandon-info :ownOrders="$ownOrders" :orders="$orders"></x-components.bandon-info>
 </x-layout>

--- a/resources/views/orders.blade.php
+++ b/resources/views/orders.blade.php
@@ -1,0 +1,6 @@
+<x-layout>
+    <x-slot:productName>
+        DinBanDon-Order
+    </x-slot:productName>
+    <x-components.bandon-order :responseData="$responseData"></x-components.bandon-order>
+</x-layout>

--- a/resources/views/store.blade.php
+++ b/resources/views/store.blade.php
@@ -1,0 +1,6 @@
+<x-layout>
+    <x-slot:productName>
+        Store
+    </x-slot:productName>
+    <x-components.bandon-info :menus='$menus' :storeInfo='$storeInfo'></x-components.bandon-info>
+</x-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,8 +22,8 @@ Route::middleware('auth')->prefix('meetings')->group(function () {
 
 Route::middleware('auth')->prefix('dinbandon')->group(function () {
     Route::get('/', [OrderController::class, 'index']);
-    Route::get('addorders', [OrderController::class, 'storeInfo']);
-    Route::get('addstores', function () {
+    Route::get('order/create', [OrderController::class, 'storeInfo']);
+    Route::get('store/create', function () {
         return view('add-store');
     });
     Route::apiResource('stores', StoreController::class)->only(['index', 'show', 'store']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Auth\SessionController;
 use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\MeetingController;
+use App\Http\Controllers\StoreController;
 use Illuminate\Contracts\Session\Session;
 
 Route::get('/', function () {
@@ -22,6 +23,7 @@ Route::middleware('auth')->prefix('dinbandon')->group(function () {
     Route::get('/', function () {
         return view('bandon');
     });
+    Route::apiResource('stores', StoreController::class)->only(['index', 'show', 'store']);
 });
 
 Route::get('/register', function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,9 @@ Route::middleware('auth')->prefix('dinbandon')->group(function () {
     Route::get('/', function () {
         return view('bandon');
     });
+    Route::get('addstores', function () {
+        return view('add-store');
+    });
     Route::apiResource('stores', StoreController::class)->only(['index', 'show', 'store']);
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,11 +22,10 @@ Route::middleware('auth')->prefix('meetings')->group(function () {
 
 Route::middleware('auth')->prefix('dinbandon')->group(function () {
     Route::get('/', [OrderController::class, 'index']);
-    Route::get('addstores', function () {
-        return view('add-store');
-    });
+    Route::get('addorders', [OrderController::class, 'storeInfo']);
     Route::apiResource('stores', StoreController::class)->only(['index', 'show', 'store']);
-    Route::apiResource('orders', OrderController::class)->only(['index', 'show', 'store', 'update']);
+    Route::apiResource('orders', OrderController::class)->only(['index', 'show', 'store']);
+    Route::patch('orders/{id}', [OrderController::class, 'update'])->where('id', '[0-9]+');
 });
 
 Route::get('/register', function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,9 @@ Route::middleware('auth')->prefix('meetings')->group(function () {
 Route::middleware('auth')->prefix('dinbandon')->group(function () {
     Route::get('/', [OrderController::class, 'index']);
     Route::get('addorders', [OrderController::class, 'storeInfo']);
+    Route::get('addstores', function () {
+        return view('add-store');
+    });
     Route::apiResource('stores', StoreController::class)->only(['index', 'show', 'store']);
     Route::apiResource('orders', OrderController::class)->only(['index', 'show', 'store']);
     Route::patch('orders/{id}', [OrderController::class, 'update'])->where('id', '[0-9]+');

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Auth\SessionController;
 use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\MeetingController;
+use App\Http\Controllers\OrderController;
 use App\Http\Controllers\StoreController;
 use Illuminate\Contracts\Session\Session;
 
@@ -20,13 +21,12 @@ Route::middleware('auth')->prefix('meetings')->group(function () {
 });
 
 Route::middleware('auth')->prefix('dinbandon')->group(function () {
-    Route::get('/', function () {
-        return view('bandon');
-    });
+    Route::get('/', [OrderController::class, 'index']);
     Route::get('addstores', function () {
         return view('add-store');
     });
     Route::apiResource('stores', StoreController::class)->only(['index', 'show', 'store']);
+    Route::apiResource('orders', OrderController::class)->only(['index', 'show', 'store', 'update']);
 });
 
 Route::get('/register', function () {


### PR DESCRIPTION
> **Seeder部分我都只要有資料可以讓我去測試就好，所以不會特別去考慮商業邏輯是否有符合**
> 目前已經有發現的問題
> 前端：把重複的code拉出來共用
> 後端：如果是使用者建立的團購單應該會需要顯示總金額以及誰沒有繳費

這階段因為如果在延續上一階段的結構好像沒有太多意義
所以把後端所有東西都拆分成RepositoriesInterface、Repositories、Service、Requests
Response 部分因為這階段的我東西完全就以MVP去實作並沒太著重在是否要去預防錯誤的問題，所以暫不實作
 
另外得提到的部分是，下面這兩個檔案我完全就是放任AI產出來前端畫面讓我使用，所以整個的code會比較亂，畫面會是像下面這樣呈現
resources/views/add-order.blade.php
resources/views./components/bandon-order.blade.php
<img width="1286" alt="image" src="https://github.com/user-attachments/assets/24c627f0-970e-4489-b419-e4cc3e081514" />
<img width="1304" alt="image" src="https://github.com/user-attachments/assets/418cc016-40c9-44b6-bf56-cc855467d947" />


## 整體流程
點進去預設會顯示有參與的訂購訂單有哪些
<img width="1266" alt="image" src="https://github.com/user-attachments/assets/b71344e7-98b7-45ec-864e-84310b5eb9c9" />
點擊任意菜單都會導向這個頁面顯示商店和菜單等資訊，並給使用者去填修改自己訂單
**`因為刪除會涉及到繳費跟未繳費的退費問題，所以也不在這階段實作，另外就是因為每筆訂單當初並沒有預想到會需要有一個欄位來區分每筆紀錄，所以目前先用品項名稱、是否已付款、份量、備註，故備注不給使用者修改`**
<img width="688" alt="image" src="https://github.com/user-attachments/assets/2e965194-d4b9-469a-8355-61258ee7d8d6" />
<img width="1228" alt="image" src="https://github.com/user-attachments/assets/6506f768-12e8-4e68-b1cd-3288a7808e46" />



### 商店
商店資訊會以這方式呈現，點擊進去後會顯示商店和菜單資訊
<img width="1314" alt="image" src="https://github.com/user-attachments/assets/87d44aff-b9e1-4df3-80aa-62cfe5a409f5" />
<img width="1212" alt="image" src="https://github.com/user-attachments/assets/1f1ab560-f6b2-442c-828f-c869c9b1b07e" />

### 訂購
訂購頁面會區分成兩個區塊
1. 使用者開的團購單
2. 使用者有參與訂購的團購單
<img width="1169" alt="image" src="https://github.com/user-attachments/assets/81ade0ef-60dc-42ba-8b2f-b3c824d079d3" />
新增團購單頁面，會讓使用者填寫日期，點擊該店家會浮窗顯示店家資訊和菜單
<img width="1304" alt="image" src="https://github.com/user-attachments/assets/7b94e988-fa0b-4ae0-a7ed-2f0afe21b833" />
<img width="1344" alt="image" src="https://github.com/user-attachments/assets/ecc688eb-5e65-4a52-8724-5014778c0604" />


